### PR TITLE
Implement Cancel Order for Customer and Vendor

### DIFF
--- a/PocketShop.xcodeproj/project.pbxproj
+++ b/PocketShop.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		02AD424C27DF2FB800F44822 /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AD424B27DF2FB800F44822 /* RegisterViewModel.swift */; };
 		02AD425F27E07F2800F44822 /* PSRadioButtonGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AD425E27E07F2800F44822 /* PSRadioButtonGroup.swift */; };
 		2B02BB0327E74DF00066A192 /* ShopOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B02BB0227E74DF00066A192 /* ShopOrderScreen.swift */; };
+		2B54157D27F5AD0400B9C758 /* OrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B54157C27F5AD0400B9C758 /* OrderViewModel.swift */; };
 		2B63EB8A27E23269008D5747 /* CustomerOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B63EB8927E23269008D5747 /* CustomerOrderScreen.swift */; };
 		2B786B4A27E33F1600834CA4 /* RingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B786B4927E33F1600834CA4 /* RingView.swift */; };
 		AD15B39827E36E9B00513809 /* DBShop.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD15B39727E36E9B00513809 /* DBShop.swift */; };
@@ -147,6 +148,7 @@
 		02AD424B27DF2FB800F44822 /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		02AD425E27E07F2800F44822 /* PSRadioButtonGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PSRadioButtonGroup.swift; sourceTree = "<group>"; };
 		2B02BB0227E74DF00066A192 /* ShopOrderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopOrderScreen.swift; sourceTree = "<group>"; };
+		2B54157C27F5AD0400B9C758 /* OrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderViewModel.swift; sourceTree = "<group>"; };
 		2B63EB8927E23269008D5747 /* CustomerOrderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerOrderScreen.swift; sourceTree = "<group>"; };
 		2B786B4927E33F1600834CA4 /* RingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingView.swift; sourceTree = "<group>"; };
 		AD15B39727E36E9B00513809 /* DBShop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBShop.swift; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 				022EA90327E731F0003F4E3C /* VendorViewModel.swift */,
 				02AD422B27DF1FC700F44822 /* LoginViewModel.swift */,
 				02AD424B27DF2FB800F44822 /* RegisterViewModel.swift */,
+				2B54157C27F5AD0400B9C758 /* OrderViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -677,6 +680,7 @@
 				022EA90927E76279003F4E3C /* ShopInfoView.swift in Sources */,
 				02AD41FD27DF024A00F44822 /* CustomerSearchScreen.swift in Sources */,
 				DFD49A0327E4B9010067BC32 /* CustomerShopView.swift in Sources */,
+				2B54157D27F5AD0400B9C758 /* OrderViewModel.swift in Sources */,
 				02AD424C27DF2FB800F44822 /* RegisterViewModel.swift in Sources */,
 				ADAD9F2B27DDE7B400DE0EE7 /* Vendor.swift in Sources */,
 				ADAD9F3527DFBBF600DE0EE7 /* DatabaseInterface.swift in Sources */,

--- a/PocketShop/Model/Order.swift
+++ b/PocketShop/Model/Order.swift
@@ -10,27 +10,4 @@ struct Order: Hashable, Identifiable {
     var date: Date
     var collectionNo: Int
     var total: Double
-
-    var isHistory: Bool {
-        status == .collected
-    }
-
-    var ringColor: Color {
-        switch status {
-        case .pending, .accepted, .preparing:
-            return .gray6
-        case .ready, .collected:
-            return .success
-        }
-    }
-
-    private let dateFormatter = DateFormatter()
-    var orderDateString: String {
-        dateFormatter.dateFormat = "dd/MM/yyyy"
-        return dateFormatter.string(from: date)
-    }
-    var orderTimeString: String {
-        dateFormatter.dateFormat = "HH:mm a"
-        return dateFormatter.string(from: date)
-    }
 }

--- a/PocketShop/ShopViews/ShopOrderScreen.swift
+++ b/PocketShop/ShopViews/ShopOrderScreen.swift
@@ -4,7 +4,7 @@ import Combine
 struct ShopOrderScreen: View {
     @ObservedObject private(set) var viewModel: ViewModel
     @State private var showConfirmation = false
-    @State private var selectedOrder: Order?
+    @State private var selectedOrder: OrderViewModel?
 
     var body: some View {
         NavigationView {
@@ -42,7 +42,7 @@ struct ShopOrderScreen: View {
     }
 
     @ViewBuilder
-    func OrderItem(order: Order) -> some View {
+    func OrderItem(order: OrderViewModel) -> some View {
         HStack(alignment: .top) {
             VStack {
                 Text("COLLECTION NO.")
@@ -110,7 +110,7 @@ struct ShopOrderScreen: View {
         }
     }
 
-    private func getAlertForOrder(_ order: Order) -> Alert {
+    private func getAlertForOrder(_ order: OrderViewModel) -> Alert {
         if order.status == .accepted {
             return Alert(
                 title: Text("Confirmation"),
@@ -144,7 +144,7 @@ extension ShopOrderScreen {
 extension ShopOrderScreen {
     class ViewModel: ObservableObject {
         @ObservedObject private var vendorViewModel: VendorViewModel
-        @Published var filteredOrders: [Order] = []
+        @Published var filteredOrders: [OrderViewModel] = []
 
         @Published var tabSelection: TabView {
             didSet {
@@ -170,22 +170,26 @@ extension ShopOrderScreen {
         func setFilterCurrent() {
             filteredOrders = vendorViewModel.orders.filter { order in
                 order.status != .collected
+            }.map {
+                OrderViewModel(order: $0)
             }
         }
 
         func setFilterHistory() {
             filteredOrders = vendorViewModel.orders.filter { order in
                 order.status == .collected
+            }.map {
+                OrderViewModel(order: $0)
             }
         }
 
-        func setOrderReady(order: Order) {
+        func setOrderReady(order: OrderViewModel) {
             // Used id so when order needs to be adapted as view model,
             // we can still use this function
             vendorViewModel.setOrderReady(orderId: order.id)
         }
 
-        func setOrderCollected(order: Order) {
+        func setOrderCollected(order: OrderViewModel) {
             vendorViewModel.setOrderCollected(orderId: order.id)
         }
     }

--- a/PocketShop/ViewModels/CustomerViewModel.swift
+++ b/PocketShop/ViewModels/CustomerViewModel.swift
@@ -123,6 +123,10 @@ final class CustomerViewModel: ObservableObject {
             }
         }
     }
+    
+    func deleteOrder(orderId: String) {
+        DatabaseInterface.db.deleteOrder(id: orderId)
+    }
 
     private func resolveErrors(_ error: Error?) -> Bool {
         if let error = error {

--- a/PocketShop/ViewModels/OrderViewModel.swift
+++ b/PocketShop/ViewModels/OrderViewModel.swift
@@ -44,6 +44,10 @@ struct OrderViewModel {
             return .success
         }
     }
+    
+    var showCancel: Bool {
+        return status == .pending
+    }
 
     private let dateFormatter = DateFormatter()
     var orderDateString: String {

--- a/PocketShop/ViewModels/OrderViewModel.swift
+++ b/PocketShop/ViewModels/OrderViewModel.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SwiftUI
+
+struct OrderViewModel {
+    private let model: Order
+    
+    var id: String {
+        model.id
+    }
+    
+    var orderProducts: [OrderProduct] {
+        model.orderProducts
+    }
+    
+    var status: OrderStatus {
+        model.status
+    }
+    
+    var shopName: String {
+        model.shopName
+    }
+    
+    var collectionNo: Int {
+        model.collectionNo
+    }
+    
+    var total: Double {
+        model.total
+    }
+    
+    init(order: Order) {
+        self.model = order
+    }
+    
+    var isHistory: Bool {
+        status == .collected
+    }
+
+    var ringColor: Color {
+        switch status {
+        case .pending, .accepted, .preparing:
+            return .gray6
+        case .ready, .collected:
+            return .success
+        }
+    }
+
+    private let dateFormatter = DateFormatter()
+    var orderDateString: String {
+        dateFormatter.dateFormat = "dd/MM/yyyy"
+        return dateFormatter.string(from: model.date)
+    }
+    var orderTimeString: String {
+        dateFormatter.dateFormat = "HH:mm a"
+        return dateFormatter.string(from: model.date)
+    }
+}
+
+extension OrderViewModel: Hashable {
+    static func == (lhs: OrderViewModel, rhs: OrderViewModel) -> Bool {
+        lhs.model == rhs.model
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/PocketShop/ViewModels/VendorViewModel.swift
+++ b/PocketShop/ViewModels/VendorViewModel.swift
@@ -98,32 +98,24 @@ final class VendorViewModel: ObservableObject {
         }
         products.remove(atOffsets: positions)
     }
+    
+    func deleteOrder(orderId: String) {
+        DatabaseInterface.db.deleteOrder(id: orderId)
+    }
+    
+    func setOrderAccept(orderId: String) {
+        setOrderStatus(orderId: orderId, status: .accepted)
+    }
 
     func setOrderReady(orderId: String) {
-        let filteredOrder = self.orders.filter { order in
-            order.id == orderId
-        }
-
-        guard filteredOrder.count == 1 else {
-            fatalError("The order id \(orderId) does not appear in order")
-        }
-
-        let order = filteredOrder[0]
-
-        let editedOrder = Order(id: order.id,
-                                orderProducts: order.orderProducts,
-                                status: .ready,
-                                customerId: order.customerId,
-                                shopId: order.shopId,
-                                shopName: order.shopName,
-                                date: order.date,
-                                collectionNo: order.collectionNo,
-                                total: order.total)
-
-        DatabaseInterface.db.editOrder(order: editedOrder)
+        setOrderStatus(orderId: orderId, status: .ready)
     }
 
     func setOrderCollected(orderId: String) {
+        setOrderStatus(orderId: orderId, status: .collected)
+    }
+    
+    private func setOrderStatus(orderId: String, status: OrderStatus) {
         let filteredOrder = self.orders.filter { order in
             order.id == orderId
         }
@@ -136,7 +128,7 @@ final class VendorViewModel: ObservableObject {
 
         let editedOrder = Order(id: order.id,
                                 orderProducts: order.orderProducts,
-                                status: .collected,
+                                status: status,
                                 customerId: order.customerId,
                                 shopId: order.shopId,
                                 shopName: order.shopName,
@@ -145,7 +137,6 @@ final class VendorViewModel: ObservableObject {
                                 total: order.total)
 
         DatabaseInterface.db.editOrder(order: editedOrder)
-
     }
 
     // MARK: Private functions

--- a/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
@@ -39,7 +39,7 @@ struct CustomerOrderScreen: View {
     }
 
     @ViewBuilder
-    func OrderItem(order: Order) -> some View {
+    func OrderItem(order: OrderViewModel) -> some View {
         HStack(alignment: .top) {
             VStack {
                 Text("COLLECTION NO.")
@@ -107,7 +107,7 @@ extension CustomerOrderScreen {
 extension CustomerOrderScreen {
     class ViewModel: ObservableObject {
         @ObservedObject var customerViewModel: CustomerViewModel
-        @Published var filteredOrders: [Order] = []
+        @Published var filteredOrders: [OrderViewModel] = []
 
         @Published var tabSelection: TabView {
             didSet {
@@ -137,12 +137,16 @@ extension CustomerOrderScreen {
         func setFilterCurrent() {
             filteredOrders = customerViewModel.orders.filter {
                 $0.status != OrderStatus.collected
+            }.map {
+                OrderViewModel(order: $0)
             }
         }
 
         func setFilterHistory() {
             filteredOrders = customerViewModel.orders.filter {
                 $0.status == OrderStatus.collected
+            }.map {
+                OrderViewModel(order: $0)
             }
         }
     }

--- a/PocketShop/Views/CustomerViews/ProductOrderBar.swift
+++ b/PocketShop/Views/CustomerViews/ProductOrderBar.swift
@@ -39,7 +39,7 @@ struct ProductOrderBar: View {
 
                     let orderProduct = OrderProduct(id: "dummyId",
                                                     quantity: quantity,
-                                                    status: .accepted,
+                                                    status: .pending,
                                                     total: 0,
                                                     productName: product.name,
                                                     productPrice: product.price,
@@ -48,7 +48,7 @@ struct ProductOrderBar: View {
                                                     shopId: product.shopId)
                     let order = Order(id: "dummyId",
                                       orderProducts: [orderProduct],
-                                      status: .accepted,
+                                      status: .pending,
                                       customerId: customerId,
                                       shopId: product.shopId,
                                       shopName: product.shopName,


### PR DESCRIPTION
Resolves #33 

Changes made:
- Refactored `Order` model. View-related properties has been ported over `OrderViewModel`
- Order made by customers will by default set its status to `pending` instead of `accepted`
- Vendor now can accept `pending` orders
- Vendor can cancel order if and only if the status is `pending`
- Customer can cancel order if and only if the status is `pending`
- Now order will show "Cancel" button below the ring as shown in the picture (UI might not be as good as expected :" ) 

![Screenshot 2022-03-31 at 9 11 19 PM](https://user-images.githubusercontent.com/62839374/161062559-77966b4a-bd4a-4512-bf11-63a955f1ca94.png)

