### PR TITLE
Improve edit products UX

### DIFF
--- a/PocketShop/Database/RealtimeDatabase/DBCart.swift
+++ b/PocketShop/Database/RealtimeDatabase/DBCart.swift
@@ -50,7 +50,7 @@ class DBCart {
                         return
                     }
                     let cartProductsToEdit = cartProducts.filter { $0.product.id == product.id }
-                    cartProducts.removeAll() { $0.product.id == product.id }
+                    cartProducts.removeAll { $0.product.id == product.id }
                     if cartProductsToEdit.isEmpty {
                         let newCartProduct = CartProduct(product: product, quantity: cartProductSchema.quantity)
                         cartProducts.append(newCartProduct)
@@ -73,7 +73,7 @@ class DBCart {
         ref.observe(.childChanged) { snapshot in
             if let value = snapshot.value, let cartProductSchema = self.convertCartProductSchema(cartProductJson: value) {
                 let cartProductsToEdit = cartProducts.filter { $0.product.id == cartProductSchema.productId }
-                cartProducts.removeAll() { $0.product.id == cartProductSchema.productId }
+                cartProducts.removeAll { $0.product.id == cartProductSchema.productId }
                 var newCartProducts = [CartProduct]()
                 for cartProduct in cartProductsToEdit {
                     var newCartProduct = cartProduct
@@ -88,7 +88,7 @@ class DBCart {
         ref.observe(.childRemoved) { snapshot in
             if let value = snapshot.value, let cartProductSchema = self.convertCartProductSchema(cartProductJson: value) {
                 let cartProductsToDelete = cartProducts.filter { $0.product.id == cartProductSchema.productId }
-                cartProducts.removeAll() { $0.product.id == cartProductSchema.productId }
+                cartProducts.removeAll { $0.product.id == cartProductSchema.productId }
                 if let remover = listenerRemovers[cartProductSchema.productId] {
                     remover()
                 }

--- a/PocketShop/Database/RealtimeDatabase/DBUsers.swift
+++ b/PocketShop/Database/RealtimeDatabase/DBUsers.swift
@@ -24,7 +24,8 @@ class DBUsers {
     }
 
     func getUser(with id: String, completionHandler: @escaping (DatabaseError?, User?) -> Void) {
-        FirebaseManager.sharedManager.ref.child("customers/\(id)").observeSingleEvent(of: .value, with: { snapshot in
+        FirebaseManager.sharedManager.ref.child("customers/\(id)").observeSingleEvent(of: .value,
+                                                                                      with: { snapshot in
             if snapshot.exists(), let value = snapshot.value {
                 do {
                     let jsonData = try JSONSerialization.data(withJSONObject: value)
@@ -35,7 +36,8 @@ class DBUsers {
                 }
                 return
             } else {
-                FirebaseManager.sharedManager.ref.child("vendors/\(id)").observeSingleEvent(of: .value, with: { snapshot in
+                FirebaseManager.sharedManager.ref.child("vendors/\(id)").observeSingleEvent(of: .value,
+                                                                                            with: { snapshot in
                     if snapshot.exists(), let value = snapshot.value {
                         do {
                             let jsonData = try JSONSerialization.data(withJSONObject: value)

--- a/PocketShop/Database/Schema/ProductSchema.swift
+++ b/PocketShop/Database/Schema/ProductSchema.swift
@@ -30,8 +30,8 @@ struct ProductSchema: Codable {
         let options = Array((self.options ?? [:]).values)
 
         return Product(id: self.id, name: self.name, shopName: shopName, shopId: shopId,
-                description: self.description, price: self.price, imageURL: self.imageURL,
-                estimatedPrepTime: self.estimatedPrepTime, isOutOfStock: self.isOutOfStock,
-                shopCategory: self.shopCategory, options: options)
+                       description: self.description, price: self.price, imageURL: self.imageURL,
+                       estimatedPrepTime: self.estimatedPrepTime, isOutOfStock: self.isOutOfStock,
+                       shopCategory: self.shopCategory, options: options)
     }
 }

--- a/PocketShop/Database/Schema/ShopSchema.swift
+++ b/PocketShop/Database/Schema/ShopSchema.swift
@@ -36,7 +36,7 @@ struct ShopSchema: Codable {
             }
         }
         let categories = Array((self.categories ?? [:]).values)
-        
+
         return Shop(id: self.id, name: self.name, description: self.description,
                     imageURL: self.imageURL, isClosed: self.isClosed,
                     collectionNumber: self.collectionNumber, ownerId: self.ownerId,

--- a/PocketShop/Model/Product.swift
+++ b/PocketShop/Model/Product.swift
@@ -12,6 +12,6 @@ struct Product: Hashable, Identifiable {
     var options: [ProductOption]
 
     var optionChoices: [ProductOptionChoice] {
-        options.map({ $0.optionChoices }).reduce([], +)
+        options.flatMap { $0.optionChoices }
     }
 }

--- a/PocketShop/ShopViews/ShopOrderScreen.swift
+++ b/PocketShop/ShopViews/ShopOrderScreen.swift
@@ -168,8 +168,8 @@ struct ShopOrderScreen: View {
 
 extension ShopOrderScreen {
     enum TabView: String {
-        case current = "current"
-        case history = "history"
+        case current
+        case history
     }
 }
 

--- a/PocketShop/ShopViews/ShopOrderScreen.swift
+++ b/PocketShop/ShopViews/ShopOrderScreen.swift
@@ -106,7 +106,7 @@ struct ShopOrderScreen: View {
                     }
 
                 Spacer()
-                
+
                 if order.showCancel {
                     PSButton(title: "Cancel") {
                         showCancelConfirmation.toggle()
@@ -125,7 +125,7 @@ struct ShopOrderScreen: View {
             .frame(minHeight: 128)
         }
     }
-    
+
     private func getCancelAlertForOrder(_ order: OrderViewModel) -> Alert {
         Alert(title: Text("Confirmation"),
               message: Text("Confirm to cancel order \(order.collectionNo)?"),
@@ -145,7 +145,7 @@ struct ShopOrderScreen: View {
                 },
                 secondaryButton: .destructive(Text("Cancel")))
         }
-        
+
         if order.status == .accepted {
             return Alert(
                 title: Text("Confirmation"),
@@ -215,11 +215,11 @@ extension ShopOrderScreen {
                 OrderViewModel(order: $0)
             }
         }
-        
+
         func cancelOrder(order: OrderViewModel) {
             vendorViewModel.deleteOrder(orderId: order.id)
         }
-        
+
         func setOrderAccept(order: OrderViewModel) {
             vendorViewModel.setOrderAccept(orderId: order.id)
         }

--- a/PocketShop/ShopViews/ShopProductEditFormView.swift
+++ b/PocketShop/ShopViews/ShopProductEditFormView.swift
@@ -34,7 +34,8 @@ struct ShopProductEditFormView: View {
                 PSImagePicker(title: "Product Image",
                               image: $image)
                     .onAppear {
-                        DatabaseManager.sharedDatabaseManager.getProductImage(productId: product.id, completionHandler: { error, imgData in
+                        DatabaseManager.sharedDatabaseManager.getProductImage(productId: product.id,
+                                                                              completionHandler: { error, imgData in
                             guard let imgData = imgData, error == nil else {
                                 return
                             }
@@ -43,28 +44,52 @@ struct ShopProductEditFormView: View {
                     }
                     .padding(.bottom)
 
-                PSButton(title: "Save") {
-                    guard let image = image, !name.isEmpty,
-                          let price = Double(price),
-                          let estimatedPrepTime = Double(prepTime) else {
-                        return
-                    }
-                    // Create Product and save to db
-                    viewModel.editProduct(oldProductId: product.id,
-                                          name: name,
-                                          description: description,
-                                          price: price,
-                                          estimatedPrepTime: estimatedPrepTime,
-                                          image: image)
-                    presentationMode.wrappedValue.dismiss()
-
-                }
-                .buttonStyle(FillButtonStyle())
+                SaveEditedProductButton(viewModel: viewModel, product: product,
+                                        name: $name, price: $price, description: $description,
+                                        prepTime: $prepTime, image: $image)
             }
             .padding()
         }
         .navigationBarItems(trailing: Button("Cancel") {
             presentationMode.wrappedValue.dismiss()
         })
+    }
+}
+
+struct SaveEditedProductButton: View {
+    @StateObject var viewModel: VendorViewModel
+    @Environment(\.presentationMode) var presentationMode
+    var product: Product
+
+    @Binding var name: String
+    @Binding var price: String
+    @Binding var description: String
+    @Binding var prepTime: String
+    @Binding var image: UIImage?
+
+    var body: some View {
+        PSButton(title: "Save") {
+            guard let image = image, !name.isEmpty,
+                  let price = Double(price),
+                  let estimatedPrepTime = Double(prepTime) else {
+                return
+            }
+            // Create edited Product and save to db
+            let product = Product(id: product.id,
+                                  name: name,
+                                  shopName: product.shopName,
+                                  shopId: product.shopId,
+                                  description: description,
+                                  price: price,
+                                  imageURL: "",
+                                  estimatedPrepTime: estimatedPrepTime,
+                                  isOutOfStock: false,
+                                  options: [])
+
+            viewModel.editProduct(newProduct: product, image: image)
+            presentationMode.wrappedValue.dismiss()
+
+        }
+        .buttonStyle(FillButtonStyle())
     }
 }

--- a/PocketShop/ShopViews/ShopProductEditFormView.swift
+++ b/PocketShop/ShopViews/ShopProductEditFormView.swift
@@ -14,10 +14,10 @@ struct ShopProductEditFormView: View {
     init(viewModel: VendorViewModel, product: Product) {
         self._viewModel = StateObject(wrappedValue: viewModel)
         self.product = product
-        self.name = product.name
-        self.price = String(product.price)
-        self.description = product.description
-        self.prepTime = String(product.estimatedPrepTime)
+        self._name = State(initialValue: product.name)
+        self._price = State(initialValue: String(product.price))
+        self._description = State(initialValue: product.description)
+        self._prepTime = State(initialValue: String(product.estimatedPrepTime))
     }
 
     var body: some View {
@@ -33,6 +33,14 @@ struct ShopProductEditFormView: View {
 
                 PSImagePicker(title: "Product Image",
                               image: $image)
+                    .onAppear {
+                        DatabaseManager.sharedDatabaseManager.getProductImage(productId: product.id, completionHandler: { error, imgData in
+                            guard let imgData = imgData, error == nil else {
+                                return
+                            }
+                            image = UIImage(data: imgData)
+                        })
+                    }
                     .padding(.bottom)
 
                 PSButton(title: "Save") {

--- a/PocketShop/ShopViews/ShopProductEditFormView.swift
+++ b/PocketShop/ShopViews/ShopProductEditFormView.swift
@@ -67,29 +67,61 @@ struct SaveEditedProductButton: View {
     @Binding var prepTime: String
     @Binding var image: UIImage?
 
+    @State private var showAlert = false
+    @State private var alertMessage = ""
+
     var body: some View {
         PSButton(title: "Save") {
-            guard let image = image, !name.isEmpty,
-                  let price = Double(price),
-                  let estimatedPrepTime = Double(prepTime) else {
+            guard let image = image else {
+                alertMessage = "Missing product image!"
+                showAlert = true
                 return
             }
-            // Create edited Product and save to db
-            let product = Product(id: product.id,
-                                  name: name,
-                                  shopName: product.shopName,
-                                  shopId: product.shopId,
-                                  description: description,
-                                  price: price,
-                                  imageURL: "",
-                                  estimatedPrepTime: estimatedPrepTime,
-                                  isOutOfStock: false,
-                                  options: [])
 
-            viewModel.editProduct(newProduct: product, image: image)
+            guard let newProduct = createEditedProduct() else {
+                print("Product edit unsuccessful")
+                return
+            }
+
+            viewModel.editProduct(newProduct: newProduct, image: image)
             presentationMode.wrappedValue.dismiss()
-
+        }
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text(alertMessage), dismissButton: .default(Text("Ok")))
         }
         .buttonStyle(FillButtonStyle())
+    }
+
+    func createEditedProduct() -> Product? {
+        guard !name.isEmpty else {
+            alertMessage = "Product name cannot be empty!"
+            showAlert = true
+            return nil
+        }
+
+        guard let price = Double(price) else {
+            alertMessage = price.isEmpty ? "Product price can't be empty!" : "Product price must be a valid double!"
+            showAlert = true
+            return nil
+        }
+
+        guard let estimatedPrepTime = Double(prepTime) else {
+            alertMessage = prepTime.isEmpty ? "Product prep time can't be empty!"
+                                            : "Product prep time must be a valid double!"
+            showAlert = true
+            return nil
+        }
+
+        // Create edited Product and save to db
+        return Product(id: product.id,
+                       name: name,
+                       shopName: product.shopName,
+                       shopId: product.shopId,
+                       description: description,
+                       price: price,
+                       imageURL: "",
+                       estimatedPrepTime: estimatedPrepTime,
+                       isOutOfStock: false,
+                       options: [])
     }
 }

--- a/PocketShop/ShopViews/ShopProductFormView.swift
+++ b/PocketShop/ShopViews/ShopProductFormView.swift
@@ -13,27 +13,20 @@ struct ShopProductFormView: View {
     var body: some View {
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 16) {
-                Text("Add new product").font(.appTitle)
+                Text("Add new product")
+                    .font(.appTitle)
+
                 UserInputSegment(name: $name,
                                  price: $price,
                                  description: $description,
                                  prepTime: $prepTime)
-                PSImagePicker(title: "Product Image",
-                              image: $image).padding(.bottom)
-                PSButton(title: "Save") {
-                    guard let image = image, !name.isEmpty,
-                          let price = Double(price),
-                          let estimatedPrepTime = Double(prepTime) else {
-                        return
-                    }
-                    // Create Product and save to db
-                    viewModel.createProduct(name: name,
-                                            description: description,
-                                            price: price,
-                                            estimatedPrepTime: estimatedPrepTime,
-                                            image: image)
-                    presentationMode.wrappedValue.dismiss()
-                }.buttonStyle(FillButtonStyle())
+
+                PSImagePicker(title: "Product Image", image: $image)
+                    .padding(.bottom)
+
+                SaveNewProductButton(viewModel: viewModel, name: $name,
+                                     price: $price, prepTime: $prepTime,
+                                     description: $description, image: $image)
             }.padding()
         }
         .navigationBarItems(trailing: Button("Cancel") {
@@ -66,5 +59,36 @@ struct UserInputSegment: View {
                         title: "Estimated Prep Time",
                         placeholder: "Enter estimated prep time")
         }
+    }
+}
+
+struct SaveNewProductButton: View {
+    @StateObject var viewModel: VendorViewModel
+    @Environment(\.presentationMode) var presentationMode
+
+    @Binding var name: String
+    @Binding var price: String
+    @Binding var prepTime: String
+    @Binding var description: String
+    @Binding var image: UIImage?
+
+    var body: some View {
+        PSButton(title: "Save") {
+            guard let image = image, !name.isEmpty,
+                  let price = Double(price),
+                  let estimatedPrepTime = Double(prepTime) else {
+                return
+            }
+
+            // Create Product and save to db
+            viewModel.createProduct(name: name,
+                                    description: description,
+                                    price: price,
+                                    estimatedPrepTime: estimatedPrepTime,
+                                    image: image)
+
+            presentationMode.wrappedValue.dismiss()
+        }
+        .buttonStyle(FillButtonStyle())
     }
 }

--- a/PocketShop/ShopViews/ShopProductFormView.swift
+++ b/PocketShop/ShopViews/ShopProductFormView.swift
@@ -72,23 +72,46 @@ struct SaveNewProductButton: View {
     @Binding var description: String
     @Binding var image: UIImage?
 
+    @State private var showAlert = false
+    @State private var alertMessage = ""
+
     var body: some View {
         PSButton(title: "Save") {
-            guard let image = image, !name.isEmpty,
-                  let price = Double(price),
-                  let estimatedPrepTime = Double(prepTime) else {
+            guard !name.isEmpty else {
+                alertMessage = "Product name cannot be empty!"
+                showAlert = true
+                return
+            }
+
+            guard let price = Double(price) else {
+                alertMessage = price.isEmpty ? "Product price can't be empty!" : "Product price must be a valid double!"
+                showAlert = true
+                return
+            }
+
+            guard let estimatedPrepTime = Double(prepTime) else {
+                alertMessage = prepTime.isEmpty ? "Product prep time can't be empty!"
+                                                : "Product prep time must be a valid double!"
+                showAlert = true
+                return
+            }
+
+            guard let image = image else {
+                alertMessage = "Missing product image!"
+                showAlert = true
                 return
             }
 
             // Create Product and save to db
-            viewModel.createProduct(name: name,
-                                    description: description,
-                                    price: price,
-                                    estimatedPrepTime: estimatedPrepTime,
-                                    image: image)
+            viewModel.createProduct(name: name, description: description, price: price,
+                                    estimatedPrepTime: estimatedPrepTime, image: image)
 
             presentationMode.wrappedValue.dismiss()
         }
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text(alertMessage), dismissButton: .default(Text("Ok")))
+        }
         .buttonStyle(FillButtonStyle())
     }
+
 }

--- a/PocketShop/ViewModels/CustomerViewModel.swift
+++ b/PocketShop/ViewModels/CustomerViewModel.swift
@@ -103,7 +103,7 @@ final class CustomerViewModel: ObservableObject {
             }
         }
     }
-    
+
     private func observeCart(customerId: String) {
         DatabaseInterface.db.observeCart(userId: customerId) { [self] error, cartProducts, eventType in
             guard resolveErrors(error) else {
@@ -123,7 +123,7 @@ final class CustomerViewModel: ObservableObject {
             }
         }
     }
-    
+
     func deleteOrder(orderId: String) {
         DatabaseInterface.db.deleteOrder(id: orderId)
     }

--- a/PocketShop/ViewModels/CustomerViewModel.swift
+++ b/PocketShop/ViewModels/CustomerViewModel.swift
@@ -66,7 +66,8 @@ final class CustomerViewModel: ObservableObject {
         return invalidCartProducts
     }
 
-    private func validateCartProduct(product: Product, cartProduct: CartProduct) -> (CartValidationError, CartProduct)? {
+    private func validateCartProduct(product: Product,
+                                     cartProduct: CartProduct) -> (CartValidationError, CartProduct)? {
         if product.name != cartProduct.productName
             || product.price != cartProduct.productPrice
             || product.imageURL != cartProduct.productImageURL {

--- a/PocketShop/ViewModels/OrderViewModel.swift
+++ b/PocketShop/ViewModels/OrderViewModel.swift
@@ -3,35 +3,35 @@ import SwiftUI
 
 struct OrderViewModel {
     private let model: Order
-    
+
     var id: String {
         model.id
     }
-    
+
     var orderProducts: [OrderProduct] {
         model.orderProducts
     }
-    
+
     var status: OrderStatus {
         model.status
     }
-    
+
     var shopName: String {
         model.shopName
     }
-    
+
     var collectionNo: Int {
         model.collectionNo
     }
-    
+
     var total: Double {
         model.total
     }
-    
+
     init(order: Order) {
         self.model = order
     }
-    
+
     var isHistory: Bool {
         status == .collected
     }
@@ -44,9 +44,9 @@ struct OrderViewModel {
             return .success
         }
     }
-    
+
     var showCancel: Bool {
-        return status == .pending
+        status == .pending
     }
 
     private let dateFormatter = DateFormatter()
@@ -64,7 +64,7 @@ extension OrderViewModel: Hashable {
     static func == (lhs: OrderViewModel, rhs: OrderViewModel) -> Bool {
         lhs.model == rhs.model
     }
-    
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }

--- a/PocketShop/ViewModels/VendorViewModel.swift
+++ b/PocketShop/ViewModels/VendorViewModel.swift
@@ -66,26 +66,13 @@ final class VendorViewModel: ObservableObject {
         DatabaseInterface.db.createProduct(shopId: shop.id, product: product, imageData: image.pngData())
     }
 
-    func editProduct(oldProductId: String, name: String, description: String,
-                     price: Double, estimatedPrepTime: Double, image: UIImage) {
-
+    func editProduct(newProduct: Product, image: UIImage) {
         guard let shop = currentShop else {
             print("No current shop!")
             return
         }
 
-        let product = Product(id: oldProductId,
-                              name: name,
-                              shopName: shop.name,
-                              shopId: shop.id,
-                              description: description,
-                              price: price,
-                              imageURL: "",
-                              estimatedPrepTime: estimatedPrepTime,
-                              isOutOfStock: false,
-                              options: [])
-
-        DatabaseInterface.db.editProduct(shopId: shop.id, product: product, imageData: image.pngData())
+        DatabaseInterface.db.editProduct(shopId: shop.id, product: newProduct, imageData: image.pngData())
     }
 
     func deleteProduct(at positions: IndexSet) {

--- a/PocketShop/ViewModels/VendorViewModel.swift
+++ b/PocketShop/ViewModels/VendorViewModel.swift
@@ -98,11 +98,11 @@ final class VendorViewModel: ObservableObject {
         }
         products.remove(atOffsets: positions)
     }
-    
+
     func deleteOrder(orderId: String) {
         DatabaseInterface.db.deleteOrder(id: orderId)
     }
-    
+
     func setOrderAccept(orderId: String) {
         setOrderStatus(orderId: orderId, status: .accepted)
     }
@@ -114,7 +114,7 @@ final class VendorViewModel: ObservableObject {
     func setOrderCollected(orderId: String) {
         setOrderStatus(orderId: orderId, status: .collected)
     }
-    
+
     private func setOrderStatus(orderId: String, status: OrderStatus) {
         let filteredOrder = self.orders.filter { order in
             order.id == orderId

--- a/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
@@ -124,8 +124,8 @@ struct CustomerOrderScreen: View {
 
 extension CustomerOrderScreen {
     enum TabView: String {
-        case current = "current"
-        case history = "history"
+        case current
+        case history
     }
 }
 

--- a/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
@@ -92,7 +92,7 @@ struct CustomerOrderScreen: View {
                 RingView(color: order.ringColor, text: order.status.toString())
 
                 Spacer()
-                
+
                 if order.showCancel {
                     PSButton(title: "Cancel") {
                         showCancelConfirmation.toggle()
@@ -111,7 +111,7 @@ struct CustomerOrderScreen: View {
             .frame(minHeight: 128)
         }
     }
-    
+
     private func getCancelAlertForOrder(_ order: OrderViewModel) -> Alert {
         Alert(title: Text("Confirmation"),
               message: Text("Confirm to cancel order \(order.collectionNo)?"),
@@ -175,7 +175,7 @@ extension CustomerOrderScreen {
                 OrderViewModel(order: $0)
             }
         }
-        
+
         func cancelOrder(order: OrderViewModel) {
             customerViewModel.deleteOrder(orderId: order.id)
         }

--- a/PocketShop/Views/CustomerViews/CustomerShopView.swift
+++ b/PocketShop/Views/CustomerViews/CustomerShopView.swift
@@ -17,7 +17,9 @@ struct CustomerShopView: View {
                 List {
                     ForEach(viewModel.products) { product in
                         if product.shopName == shop.name {
-                            ProductListView(product: product).environmentObject(viewModel)
+                            NavigationLink(destination: ProductView(product: product)) {
+                                ProductListView(product: product).environmentObject(viewModel)
+                            }
                         }
                     }
                 }

--- a/PocketShop/Views/CustomerViews/ProductOrderBar.swift
+++ b/PocketShop/Views/CustomerViews/ProductOrderBar.swift
@@ -7,62 +7,69 @@ struct ProductOrderBar: View {
 
     var body: some View {
         HStack {
-            VStack {
-                // Quantity
-                Text("Quantity")
-                    .font(.appHeadline)
-                HStack {
-                    PSButton(title: "-") {
-                        if quantity > 1 { quantity -= 1 }
-                    }
-                    .buttonStyle(OutlineButtonStyle())
-                    Text(String(quantity))
-                        .font(.appButton)
-                        .padding(.horizontal)
-                    PSButton(title: "+") {
-                        if quantity < 1_000 { quantity += 1 }
-                    }
-                    .buttonStyle(OutlineButtonStyle())
-                }
-            }
-            .padding(.horizontal)
-
-            VStack {
-                // Price and order button
-                Text(String(format: "Price: $%.2f", product.price * Double(quantity)))
-                    .font(.appHeadline)
-                PSButton(title: "ORDER") {
-                    guard let customerId = customerViewModel.customer?.id else {
-                        // TODO: More helpful error message
-                        return
-                    }
-
-                    let orderProduct = OrderProduct(id: "dummyId",
-                                                    quantity: quantity,
-                                                    status: .pending,
-                                                    total: 0,
-                                                    productName: product.name,
-                                                    productPrice: product.price,
-                                                    productImageURL: product.imageURL,
-                                                    productOptionChoices: [],
-                                                    productId: product.id,
-                                                    shopId: product.shopId)
-                    let order = Order(id: "dummyId",
-                                      orderProducts: [orderProduct],
-                                      status: .pending,
-                                      customerId: customerId,
-                                      shopId: product.shopId,
-                                      shopName: product.shopName,
-                                      date: Date(),
-                                      collectionNo: 0,
-                                      total: 0)
-
-                    DatabaseInterface.db.createOrder(order: order)
-                }
-                .buttonStyle(FillButtonStyle())
-            }
-            .padding()
+            QuantitySelector(quantity: $quantity)
+            PriceAndOrderButton(customerViewModel: _customerViewModel,
+                                product: product,
+                                quantity: $quantity)
         }
         .padding(.bottom)
+    }
+}
+
+struct QuantitySelector: View {
+    @Binding var quantity: Int
+
+    var body: some View {
+        VStack {
+            Text("Quantity")
+                .font(.appHeadline)
+            HStack {
+                PSButton(title: "-") {
+                    if quantity > 1 { quantity -= 1 }
+                }
+                .buttonStyle(OutlineButtonStyle())
+                Text(String(quantity))
+                    .font(.appButton)
+                    .padding(.horizontal)
+                PSButton(title: "+") {
+                    if quantity < 1_000 { quantity += 1 }
+                }
+                .buttonStyle(OutlineButtonStyle())
+            }
+        }
+        .padding(.horizontal)
+    }
+}
+
+struct PriceAndOrderButton: View {
+    @EnvironmentObject var customerViewModel: CustomerViewModel
+    var product: Product
+    @Binding var quantity: Int
+
+    var body: some View {
+        VStack {
+            // Price and order button
+            Text(String(format: "Price: $%.2f", product.price * Double(quantity)))
+                .font(.appHeadline)
+            PSButton(title: "ORDER") {
+                guard let customerId = customerViewModel.customer?.id else {
+                    // TODO: More helpful error message
+                    return
+                }
+
+                let orderProduct = OrderProduct(id: "dummyId", quantity: quantity, status: .pending, total: 0,
+                                                productName: product.name, productPrice: product.price,
+                                                productImageURL: product.imageURL, productOptionChoices: [],
+                                                productId: product.id, shopId: product.shopId)
+
+                let order = Order(id: "dummyId", orderProducts: [orderProduct], status: .pending,
+                                  customerId: customerId, shopId: product.shopId, shopName: product.shopName,
+                                  date: Date(), collectionNo: 0, total: 0)
+
+                DatabaseInterface.db.createOrder(order: order)
+            }
+            .buttonStyle(FillButtonStyle())
+        }
+        .padding()
     }
 }


### PR DESCRIPTION
- [X] Fix missing link to product order page from customer's shop view
- [X] Make existing fields (including text and images) appear to show the user (vendor) the completed form that will replace the existing product information (fixes #43 )
- [X] Refactored for SwiftLint (reduced 22 linting warnings to 7, mainly left with some DB and order screen-related warnings)
- [x] Add alerts for editing and adding products when compulsory fields are not present (partially addresses #25 )