### PR TITLE
Fix compilation errors

### DIFF
--- a/PocketShop/ShopViews/ShopProductEditFormView.swift
+++ b/PocketShop/ShopViews/ShopProductEditFormView.swift
@@ -99,7 +99,7 @@ struct SaveEditedProductButton: View {
             return nil
         }
 
-        guard let price = Double(price) else {
+        guard let inputPrice = Double(price) else {
             alertMessage = price.isEmpty ? "Product price can't be empty!" : "Product price must be a valid double!"
             showAlert = true
             return nil
@@ -118,7 +118,7 @@ struct SaveEditedProductButton: View {
                        shopName: product.shopName,
                        shopId: product.shopId,
                        description: description,
-                       price: price,
+                       price: inputPrice,
                        imageURL: "",
                        estimatedPrepTime: estimatedPrepTime,
                        isOutOfStock: false,

--- a/PocketShop/ShopViews/ShopProductFormView.swift
+++ b/PocketShop/ShopViews/ShopProductFormView.swift
@@ -50,6 +50,7 @@ struct UserInputSegment: View {
             PSTextField(text: $price,
                         title: "Product Price",
                         placeholder: "Enter product price")
+                .keyboardType(.numberPad)
 
             PSTextField(text: $description,
                         title: "Product Description (optional)",
@@ -58,6 +59,7 @@ struct UserInputSegment: View {
             PSTextField(text: $prepTime,
                         title: "Estimated Prep Time",
                         placeholder: "Enter estimated prep time")
+                .keyboardType(.numberPad)
         }
     }
 }
@@ -83,7 +85,7 @@ struct SaveNewProductButton: View {
                 return
             }
 
-            guard let price = Double(price) else {
+            guard let inputPrice = Double(price) else {
                 alertMessage = price.isEmpty ? "Product price can't be empty!" : "Product price must be a valid double!"
                 showAlert = true
                 return
@@ -103,7 +105,7 @@ struct SaveNewProductButton: View {
             }
 
             // Create Product and save to db
-            viewModel.createProduct(name: name, description: description, price: price,
+            viewModel.createProduct(name: name, description: description, price: inputPrice,
                                     estimatedPrepTime: estimatedPrepTime, image: image)
 
             presentationMode.wrappedValue.dismiss()


### PR DESCRIPTION
My Swift version wasn't allowing the variable in guard to be used within the clause, so I renamed `price` to `inputPrice` which represents the price the user set.

Also added small improvement to the price & prep time text fields to show the numeric keyboard