### PR TITLE
Adding Product Options

### DIFF
--- a/PocketShop/Core/Components/PSImagePicker.swift
+++ b/PocketShop/Core/Components/PSImagePicker.swift
@@ -13,12 +13,10 @@ struct PSImagePicker: View {
 
             if let image = image {
                 Image(uiImage: image).resizable().scaledToFit()
+                    .frame(height: 150)
             } else {
-                Image(systemName: "photo")
-                   .resizable()
-                   .scaledToFit()
-                   .padding()
-                   .foregroundColor(Color.gray3)
+                Image(systemName: "photo").resizable().scaledToFit().padding().foregroundColor(Color.gray3)
+                    .frame(height: 150)
             }
 
             PSButton(title: "Choose Image") {

--- a/PocketShop/Core/Components/PSRadioButtonGroup.swift
+++ b/PocketShop/Core/Components/PSRadioButtonGroup.swift
@@ -4,8 +4,8 @@ struct PSRadioButtonGroup: View {
 
     let title: String
     let options: [String]
-    @State var selectedId: String = ""
-    let callback: (String) -> Void
+    @State var selectedId: Int = -1
+    let callback: (Int) -> Void
 
     var body: some View {
         HStack(spacing: 32) {
@@ -14,6 +14,7 @@ struct PSRadioButtonGroup: View {
             VStack {
                 ForEach(options.indices) { i in
                     PSRadioButton(option: options[i],
+                                  optionId: i,
                                   selectedId: selectedId,
                                   callback: self.radioGroupCallback)
                 }
@@ -22,7 +23,7 @@ struct PSRadioButtonGroup: View {
         }.frame(maxWidth: Constants.maxWidthIPad)
     }
 
-    func radioGroupCallback(toSelect: String) {
+    func radioGroupCallback(toSelect: Int) {
         selectedId = toSelect
         callback(toSelect)
     }
@@ -32,15 +33,16 @@ struct PSRadioButton: View {
     typealias selectionHandler = (String) -> Void
 
     var option: String
-    var selectedId: String
+    var optionId: Int
+    var selectedId: Int
     private var isSelected: Bool {
-        option == selectedId
+        optionId == selectedId
     }
-    let callback: (String) -> Void
+    let callback: (Int) -> Void
 
     var body: some View {
         Button {
-            callback(option)
+            callback(optionId)
         } label: {
             HStack {
                 Circle()

--- a/PocketShop/Database/RealtimeDatabase/DBCart.swift
+++ b/PocketShop/Database/RealtimeDatabase/DBCart.swift
@@ -8,9 +8,17 @@ class DBCart {
             print("Unexpected error")
             return
         }
+        var optionsPrice: Double = 0
+        if let choices = productOptionChoices {
+            optionsPrice = choices.reduce(0, { $0 + $1.cost })
+            print("calculating options price: \(optionsPrice)")
+        }
+
         let newCartProduct = CartProduct(id: key,
                                          quantity: quantity,
-                                         total: product.price * Double(quantity),
+                                         total: calculateProductTotal(price: product.price,
+                                                                      quantity: Double(quantity),
+                                                                      choiceCosts: optionsPrice),
                                          productName: product.name,
                                          productPrice: product.price,
                                          productImageURL: product.imageURL,
@@ -85,6 +93,11 @@ class DBCart {
             print(error)
             return nil
         }
+    }
+
+    private func calculateProductTotal(price: Double, quantity: Double, choiceCosts: Double) -> Double {
+        print("my product total is \(quantity * (price + choiceCosts))")
+        return quantity * (price + choiceCosts)
     }
 
 }

--- a/PocketShop/Database/RealtimeDatabase/DBCart.swift
+++ b/PocketShop/Database/RealtimeDatabase/DBCart.swift
@@ -8,17 +8,9 @@ class DBCart {
             print("Unexpected error")
             return
         }
-        var optionsPrice: Double = 0
-        if let choices = productOptionChoices {
-            optionsPrice = choices.reduce(0, { $0 + $1.cost })
-            print("calculating options price: \(optionsPrice)")
-        }
 
         let newCartProduct = CartProduct(id: key,
                                          quantity: quantity,
-                                         total: calculateProductTotal(price: product.price,
-                                                                      quantity: Double(quantity),
-                                                                      choiceCosts: optionsPrice),
                                          productName: product.name,
                                          productPrice: product.price,
                                          productImageURL: product.imageURL,
@@ -93,11 +85,6 @@ class DBCart {
             print(error)
             return nil
         }
-    }
-
-    private func calculateProductTotal(price: Double, quantity: Double, choiceCosts: Double) -> Double {
-        print("my product total is \(quantity * (price + choiceCosts))")
-        return quantity * (price + choiceCosts)
     }
 
 }

--- a/PocketShop/Database/Schema/CartProductSchema.swift
+++ b/PocketShop/Database/Schema/CartProductSchema.swift
@@ -27,7 +27,6 @@ struct CartProductSchema: Codable {
     func toCartProduct() -> CartProduct {
         CartProduct(id: self.id,
                     quantity: self.quantity,
-                    total: self.productPrice * Double(self.quantity),
                     productName: self.productName,
                     productPrice: self.productPrice,
                     productImageURL: self.productImageURL,

--- a/PocketShop/Database/Schema/CartProductSchema.swift
+++ b/PocketShop/Database/Schema/CartProductSchema.swift
@@ -26,13 +26,13 @@ struct CartProductSchema: Codable {
 
     func toCartProduct() -> CartProduct {
         CartProduct(id: self.id,
-                           quantity: self.quantity,
-                           total: self.productPrice * Double(self.quantity),
-                           productName: self.productName,
-                           productPrice: self.productPrice,
-                           productImageURL: self.productImageURL,
-                           productOptionChoices: self.productOptionChoices ?? [],
-                           shopName: self.shopName,
-                           productId: self.productId, shopId: self.shopId)
+                    quantity: self.quantity,
+                    total: self.productPrice * Double(self.quantity),
+                    productName: self.productName,
+                    productPrice: self.productPrice,
+                    productImageURL: self.productImageURL,
+                    productOptionChoices: self.productOptionChoices ?? [],
+                    shopName: self.shopName,
+                    productId: self.productId, shopId: self.shopId)
     }
 }

--- a/PocketShop/Database/Schema/OrderProductSchema.swift
+++ b/PocketShop/Database/Schema/OrderProductSchema.swift
@@ -6,7 +6,7 @@ struct OrderProductSchema: Codable {
     var productName: String
     var productPrice: Double
     var productImageURL: String
-    var productOptionChoices: [Int: ProductOptionChoice]? = [:]
+    var productOptionChoices: [ProductOptionChoice]? = []
 
     var shopName: String
 
@@ -20,19 +20,13 @@ struct OrderProductSchema: Codable {
         self.productName = orderProduct.productName
         self.productPrice = orderProduct.productPrice
         self.productImageURL = orderProduct.productImageURL
+        self.productOptionChoices = orderProduct.productOptionChoices
         self.shopName = orderProduct.shopName
         self.productId = orderProduct.productId
         self.shopId = orderProduct.shopId
-
-        var counter = 0
-        for productOptionChoice in orderProduct.productOptionChoices {
-            self.productOptionChoices?[counter] = productOptionChoice
-            counter += 1
-        }
     }
 
     func toOrderProduct() -> OrderProduct {
-        let productOptionChoices = Array((self.productOptionChoices ?? [:]).values)
         return OrderProduct(id: self.id,
                             quantity: self.quantity,
                             status: self.status,
@@ -40,7 +34,7 @@ struct OrderProductSchema: Codable {
                             productName: self.productName,
                             productPrice: self.productPrice,
                             productImageURL: self.productImageURL,
-                            productOptionChoices: productOptionChoices,
+                            productOptionChoices: self.productOptionChoices ?? [],
                             shopName: self.shopName,
                             productId: self.productId, shopId: self.shopId)
     }

--- a/PocketShop/Database/Schema/OrderProductSchema.swift
+++ b/PocketShop/Database/Schema/OrderProductSchema.swift
@@ -27,15 +27,14 @@ struct OrderProductSchema: Codable {
     }
 
     func toOrderProduct() -> OrderProduct {
-        return OrderProduct(id: self.id,
-                            quantity: self.quantity,
-                            status: self.status,
-                            total: self.productPrice * Double(self.quantity),
-                            productName: self.productName,
-                            productPrice: self.productPrice,
-                            productImageURL: self.productImageURL,
-                            productOptionChoices: self.productOptionChoices ?? [],
-                            shopName: self.shopName,
-                            productId: self.productId, shopId: self.shopId)
+        OrderProduct(id: self.id,
+                     quantity: self.quantity,
+                     status: self.status,
+                     productName: self.productName,
+                     productPrice: self.productPrice,
+                     productImageURL: self.productImageURL,
+                     productOptionChoices: self.productOptionChoices ?? [],
+                     shopName: self.shopName,
+                     productId: self.productId, shopId: self.shopId)
     }
 }

--- a/PocketShop/Model/CartProduct.swift
+++ b/PocketShop/Model/CartProduct.swift
@@ -13,6 +13,7 @@ struct CartProduct: Hashable, Identifiable {
     var productId: String
     var shopId: String
 
+    // total price is (base price + cost of each option) * quantity bought
     var total: Double {
         let optionsPrice = productOptionChoices.reduce(0, { $0 + $1.cost })
         return Double(quantity) * (productPrice + optionsPrice)

--- a/PocketShop/Model/CartProduct.swift
+++ b/PocketShop/Model/CartProduct.swift
@@ -1,7 +1,6 @@
 struct CartProduct: Hashable, Identifiable {
     var id: String
     var quantity: Int
-    var total: Double
 
     var productName: String
     var productPrice: Double
@@ -14,8 +13,13 @@ struct CartProduct: Hashable, Identifiable {
     var productId: String
     var shopId: String
 
+    var total: Double {
+        let optionsPrice = productOptionChoices.reduce(0, { $0 + $1.cost })
+        return Double(quantity) * (productPrice + optionsPrice)
+    }
+
     func toOrderProduct() -> OrderProduct {
-        OrderProduct(id: id, quantity: quantity, status: .pending, total: total,
+        OrderProduct(id: id, quantity: quantity, status: .pending,
                      productName: productName, productPrice: productPrice,
                      productImageURL: productImageURL,
                      productOptionChoices: productOptionChoices, shopName: shopName,

--- a/PocketShop/Model/OrderProduct.swift
+++ b/PocketShop/Model/OrderProduct.swift
@@ -2,12 +2,16 @@ struct OrderProduct: Hashable, Identifiable {
     var id: String
     var quantity: Int
     var status: OrderStatus
-    var total: Double
 
     var productName: String
     var productPrice: Double
     var productImageURL: String
     var productOptionChoices: [ProductOptionChoice]
+
+    var total: Double {
+        let optionsPrice = productOptionChoices.reduce(0, { $0 + $1.cost })
+        return Double(quantity) * (productPrice + optionsPrice)
+    }
 
     var shopName: String
 

--- a/PocketShop/ViewModels/RegisterViewModel.swift
+++ b/PocketShop/ViewModels/RegisterViewModel.swift
@@ -1,9 +1,9 @@
 import Combine
 import SwiftUI
 
-enum AccountType: String {
-    case customer = "Customer"
-    case vendor = "Vendor"
+enum AccountType: Int {
+    case customer = 0
+    case vendor = 1
 }
 
 final class RegisterViewModel: ObservableObject {
@@ -56,12 +56,8 @@ final class RegisterViewModel: ObservableObject {
         }
     }
 
-    func setAccountType(_ type: String) {
-        if type == "Vendor" {
-            self.accountType = AccountType.vendor
-        } else {
-            self.accountType = AccountType.customer
-        }
+    func setAccountType(_ type: Int) {
+        self.accountType = AccountType(rawValue: type)
     }
 
     // returns true if no errors

--- a/PocketShop/Views/CommonViews/RegisterScreen.swift
+++ b/PocketShop/Views/CommonViews/RegisterScreen.swift
@@ -15,7 +15,7 @@ struct RegisterScreen: View {
                                    errorMessage: $registerViewModel.errorMessage)
                     PSRadioButtonGroup(title: "I am a",
                                        options: ["Customer", "Vendor"],
-                                       selectedId: registerViewModel.accountType?.rawValue ?? "",
+                                       selectedId: registerViewModel.accountType?.rawValue ?? 0,
                                        callback: { option in
                                         registerViewModel.setAccountType(option)
                                      })

--- a/PocketShop/Views/CommonViews/ShopProfileScreen.swift
+++ b/PocketShop/Views/CommonViews/ShopProfileScreen.swift
@@ -9,6 +9,7 @@ struct ShopProfileScreen: View {
         NavigationView {
             VStack {
                 ShopOpenCloseButton()
+                ShopEditProfileButton()
                 Spacer()
                 PSButton(title: "Logout",
                          icon: "arrow.down.left.circle.fill") {
@@ -27,6 +28,28 @@ struct ShopProfileScreen: View {
 struct ShopProfileScreen_Previews: PreviewProvider {
     static var previews: some View {
         ShopProfileScreen(router: MainViewRouter())
+    }
+}
+
+struct ShopEditProfileButton: View {
+    @EnvironmentObject var viewModel: VendorViewModel
+    @State var isEditingShop = false
+
+    var shop: Shop {
+        viewModel.currentShop ?? Shop(id: "default", name: "default",
+                                      description: "default", imageURL: "default",
+                                      isClosed: true, ownerId: "default", soldProducts: [], categories: [])
+    }
+
+    var body: some View {
+        NavigationLink(
+            destination: ShopEditFormView(viewModel: viewModel,
+                                          shop: shop),
+            isActive: $isEditingShop) {
+            PSButton(title: "Edit Shop Details") {
+                isEditingShop = true
+            }
+        }
     }
 }
 

--- a/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
@@ -67,7 +67,8 @@ struct CustomerCartScreen: View {
 
                     if !cartProduct.productOptionChoices.isEmpty {
                         ForEach(cartProduct.productOptionChoices, id: \.self) { choice in
-                            Text("\(choice.description) (+$\(choice.cost))")
+                            Text("\(choice.description) (+$\(choice.cost, specifier: "%.2f"))")
+                                .font(.appBody)
                         }
                     }
 

--- a/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
@@ -65,6 +65,12 @@ struct CustomerCartScreen: View {
                         .font(.appBody)
                         .padding(.bottom)
 
+                    if !cartProduct.productOptionChoices.isEmpty {
+                        ForEach(cartProduct.productOptionChoices, id: \.self) { choice in
+                            Text("\(choice.description) (+$\(choice.cost))")
+                        }
+                    }
+
                     Text(String(format: "$%.2f", cartProduct.total))
                         .font(.appBody)
                 }

--- a/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
@@ -18,6 +18,7 @@ struct CustomerOrderScreen: View {
 
                 withAnimation(.easeInOut) {
                     OrderList()
+                        .environmentObject(viewModel)
                 }
             }
             .navigationTitle("My Orders")
@@ -43,42 +44,8 @@ struct CustomerOrderScreen: View {
     @ViewBuilder
     func OrderItem(order: OrderViewModel) -> some View {
         HStack(alignment: .top) {
-            VStack {
-                Text("COLLECTION NO.")
-                    .font(.appBody)
-
-                Spacer()
-
-                Text("\(order.collectionNo)")
-                    .font(.appFont(size: 32))
-                    .bold()
-
-                Spacer()
-
-                Text("\(order.orderDateString)")
-                    .font(.appBody)
-
-                Text("\(order.orderTimeString)")
-                    .font(.appBody)
-                    .foregroundColor(.gray)
-            }
-            .frame(minWidth: 100)
-
-            VStack(alignment: .leading, spacing: 0) {
-                Text("\(order.shopName)")
-                    .font(.appBody)
-                    .bold()
-                    .padding(.bottom, 4)
-
-                ForEach(order.orderProducts, id: \.id) { orderProduct in
-                    Text("\(orderProduct.quantity) x \(orderProduct.productName)")
-                        .font(.appSmallCaption)
-                }
-
-                Spacer()
-            }
-            .padding(.leading, 8)
-
+            CollectionNumberSection(order: order)
+            OrderDetailsSection(order: order)
             Spacer()
 
             VStack {
@@ -102,7 +69,6 @@ struct CustomerOrderScreen: View {
                         guard let selectedOrder = self.selectedOrder else {
                             fatalError("Order does not exist")
                         }
-
                         return getCancelAlertForOrder(selectedOrder)
                     }
                     .buttonStyle(FillButtonStyle())
@@ -116,7 +82,7 @@ struct CustomerOrderScreen: View {
         Alert(title: Text("Confirmation"),
               message: Text("Confirm to cancel order \(order.collectionNo)?"),
               primaryButton: .default(Text("Yes")) {
-                    viewModel.cancelOrder(order: order)
+                viewModel.cancelOrder(order: order)
               },
               secondaryButton: .destructive(Text("No")))
     }
@@ -179,6 +145,54 @@ extension CustomerOrderScreen {
         func cancelOrder(order: OrderViewModel) {
             customerViewModel.deleteOrder(orderId: order.id)
         }
+    }
+}
+
+struct CollectionNumberSection: View {
+    @State var order: OrderViewModel
+
+    var body: some View {
+        VStack {
+            Text("COLLECTION NO.")
+                .font(.appBody)
+
+            Spacer()
+
+            Text("\(order.collectionNo)")
+                .font(.appFont(size: 32))
+                .bold()
+
+            Spacer()
+
+            Text("\(order.orderDateString)")
+                .font(.appBody)
+
+            Text("\(order.orderTimeString)")
+                .font(.appBody)
+                .foregroundColor(.gray)
+        }
+        .frame(minWidth: 100)
+    }
+}
+
+struct OrderDetailsSection: View {
+    @State var order: OrderViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("\(order.shopName)")
+                .font(.appBody)
+                .bold()
+                .padding(.bottom, 4)
+
+            ForEach(order.orderProducts, id: \.id) { orderProduct in
+                Text("\(orderProduct.quantity) x \(orderProduct.productName)")
+                    .font(.appSmallCaption)
+            }
+
+            Spacer()
+        }
+        .padding(.leading, 8)
     }
 }
 

--- a/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerOrderScreen.swift
@@ -34,7 +34,8 @@ struct CustomerOrderScreen: View {
                     OrderItem(order: order)
                         .frame(maxWidth: .infinity)
                         .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
+                        .padding(.vertical, 12)
+                    Divider()
                 }
             }
         }
@@ -188,6 +189,15 @@ struct OrderDetailsSection: View {
             ForEach(order.orderProducts, id: \.id) { orderProduct in
                 Text("\(orderProduct.quantity) x \(orderProduct.productName)")
                     .font(.appSmallCaption)
+                if let choices = orderProduct.productOptionChoices {
+                    VStack(alignment: .leading) {
+                        ForEach(choices, id: \.self) { choice in
+                            Text("\(choice.description) (+$\(choice.cost, specifier: "%.2f"))")
+                                .font(.appBody)
+                        }
+                        .padding(.horizontal, 8)
+                    }
+                }
             }
 
             Spacer()

--- a/PocketShop/Views/CustomerViews/ProductOrderBar.swift
+++ b/PocketShop/Views/CustomerViews/ProductOrderBar.swift
@@ -8,7 +8,6 @@ struct ProductOrderBar: View {
     @EnvironmentObject var customerViewModel: CustomerViewModel
 
     @State var quantity: Int = 1
-//    @State var choices = [ProductOptionChoice]()
     @StateObject var choices = CustomerChoices()
     var product: Product
 
@@ -16,6 +15,7 @@ struct ProductOrderBar: View {
         VStack {
             ProductOptionsGroup(availableOptions: product.options,
                                 selectedOptions: choices)
+            Spacer()
             HStack {
                 QuantitySelector(quantity: $quantity)
                 PriceAndOrderButton(customerViewModel: _customerViewModel,

--- a/PocketShop/Views/CustomerViews/ProductOrderBar.swift
+++ b/PocketShop/Views/CustomerViews/ProductOrderBar.swift
@@ -6,13 +6,40 @@ struct ProductOrderBar: View {
     var product: Product
 
     var body: some View {
-        HStack {
-            QuantitySelector(quantity: $quantity)
-            PriceAndOrderButton(customerViewModel: _customerViewModel,
-                                product: product,
-                                quantity: $quantity)
+        VStack {
+            ProductOptionsGroup(options: product.options)
+            HStack {
+                QuantitySelector(quantity: $quantity)
+                PriceAndOrderButton(customerViewModel: _customerViewModel,
+                                    product: product,
+                                    quantity: $quantity)
+            }
         }
         .padding(.bottom)
+    }
+}
+
+struct ProductOptionsGroup: View {
+
+    @State var options: [ProductOption]
+
+    var body: some View {
+        if !options.isEmpty {
+            VStack(alignment: .leading) {
+                Text("Additional options").font(.appHeadline)
+                ScrollView(.vertical) {
+                    ForEach(options, id: \.self) { option in
+                        PSRadioButtonGroup(title: option.title,
+                                           options: option.optionChoices.map({ choice in
+                                            "\(choice.description) (+$\(choice.cost))"
+                                           }),
+                                           callback: {o in
+                                            print(o)
+                                           })
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -69,6 +96,6 @@ struct PriceAndOrderButton: View {
     func addToCart() {
         customerViewModel.addProductToCart(product,
                                            quantity: quantity,
-                                           choices: product.optionChoices)
+                                           choices: [])
     }
 }

--- a/PocketShop/Views/CustomerViews/ProductView.swift
+++ b/PocketShop/Views/CustomerViews/ProductView.swift
@@ -10,7 +10,7 @@ struct ProductView: View {
 
             URLImage(urlString: product.imageURL)
                 .scaledToFit()
-                .frame(width: 200, height: 200) // Might change to relative sizes
+                .frame(width: 150, height: 150) // Might change to relative sizes
 
             Text(product.description)
                 .padding(.vertical)
@@ -19,8 +19,6 @@ struct ProductView: View {
             Text(String(format: "$%.2f", product.price))
                 .font(.appBody)
                 .fontWeight(.semibold)
-
-            Spacer()
 
             ProductOrderBar(product: product)
         }

--- a/PocketShop/Views/ShopViews/ShopFormView.swift
+++ b/PocketShop/Views/ShopViews/ShopFormView.swift
@@ -112,6 +112,6 @@ struct ShopTextFields: View {
         }, label: {
             Text("\(Image(systemName: "plus.circle")) Add new shop category")
         })
-            .padding(.vertical)
+        .padding(.vertical)
     }
 }

--- a/PocketShop/Views/ShopViews/ShopProductEditFormView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductEditFormView.swift
@@ -11,6 +11,7 @@ struct ShopProductEditFormView: View {
     @State private var prepTime: String = ""
     @State private var image: UIImage?
     @State private var category: String = ""
+    @State private var options = [ProductOption]()
 
     init(viewModel: VendorViewModel, product: Product) {
         self.product = product
@@ -19,6 +20,7 @@ struct ShopProductEditFormView: View {
         self._description = State(initialValue: product.description)
         self._prepTime = State(initialValue: String(product.estimatedPrepTime))
         self._category = State(initialValue: product.shopCategory?.title ?? "")
+        self._options = State(initialValue: product.options)
     }
 
     var body: some View {
@@ -28,7 +30,7 @@ struct ShopProductEditFormView: View {
                     .font(.appTitle)
 
                 UserInputSegment(name: $name, price: $price, description: $description,
-                                 prepTime: $prepTime, category: $category)
+                                 prepTime: $prepTime, category: $category, options: $options)
 
                 PSImagePicker(title: "Product Image",
                               image: $image)
@@ -44,8 +46,8 @@ struct ShopProductEditFormView: View {
                     .padding(.bottom)
 
                 SaveEditedProductButton(product: product,
-                                        name: $name, price: $price, description: $description,
-                                        prepTime: $prepTime, image: $image, category: $category)
+                                        name: $name, price: $price, description: $description, prepTime: $prepTime,
+                                        image: $image, category: $category, options: $options)
             }
             .padding()
         }
@@ -66,6 +68,7 @@ struct SaveEditedProductButton: View {
     @Binding var prepTime: String
     @Binding var image: UIImage?
     @Binding var category: String
+    @Binding var options: [ProductOption]
 
     @State private var showAlert = false
     @State private var alertMessage = ""
@@ -129,6 +132,6 @@ struct SaveEditedProductButton: View {
                        estimatedPrepTime: estimatedPrepTime,
                        isOutOfStock: false,
                        shopCategory: ShopCategory(title: category),
-                       options: [])
+                       options: options)
     }
 }

--- a/PocketShop/Views/ShopViews/ShopProductFormView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductFormView.swift
@@ -10,6 +10,7 @@ struct ShopProductFormView: View {
     @State private var description = ""
     @State private var image: UIImage?
     @State private var category = ""
+    @State private var options = [ProductOption]()
 
     var body: some View {
         ScrollView(.vertical) {
@@ -21,14 +22,16 @@ struct ShopProductFormView: View {
                                  price: $price,
                                  description: $description,
                                  prepTime: $prepTime,
-                                 category: $category)
+                                 category: $category,
+                                 options: $options)
 
                 PSImagePicker(title: "Product Image", image: $image)
                     .padding(.bottom)
 
                 SaveNewProductButton(name: $name, price: $price,
                                      prepTime: $prepTime, description: $description,
-                                     image: $image, category: $category)
+                                     image: $image, category: $category,
+                                     options: $options)
             }.padding()
         }
         .navigationBarItems(trailing: Button("Cancel") {
@@ -45,6 +48,7 @@ struct UserInputSegment: View {
     @Binding var description: String
     @Binding var prepTime: String
     @Binding var category: String
+    @Binding var options: [ProductOption]
 
     var body: some View {
         VStack {
@@ -67,6 +71,8 @@ struct UserInputSegment: View {
                         title: "Estimated Prep Time",
                         placeholder: "Enter estimated prep time")
                 .keyboardType(.numberPad)
+
+            OptionGroupSection(options: $options)
         }
     }
 }
@@ -81,6 +87,7 @@ struct SaveNewProductButton: View {
     @Binding var description: String
     @Binding var image: UIImage?
     @Binding var category: String
+    @Binding var options: [ProductOption]
 
     @State private var showAlert = false
     @State private var alertMessage = ""
@@ -149,7 +156,7 @@ struct SaveNewProductButton: View {
                        estimatedPrepTime: estimatedPrepTime,
                        isOutOfStock: false,
                        shopCategory: ShopCategory(title: category),
-                       options: [])
+                       options: options)
     }
 
 }
@@ -175,5 +182,137 @@ struct CategoryPickerSection: View {
             Spacer()
         }
         .frame(maxWidth: Constants.maxWidthIPad)
+    }
+}
+
+struct OptionGroupSection: View {
+    @EnvironmentObject var viewModel: VendorViewModel
+    @Binding var options: [ProductOption]
+
+    @State var isOptionGroupModalShown = false
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text("Product Options".uppercased())
+                    .font(.appSmallCaption)
+
+                ForEach(options, id: \.self) { optionGroup in
+                    OptionGroupView(optionGroup: optionGroup)
+                }
+
+                PSButton(title: "Add Option Group") {
+                    isOptionGroupModalShown = true
+                }.buttonStyle(OutlineButtonStyle())
+            }
+            Spacer()
+        }
+        .frame(maxWidth: Constants.maxWidthIPad)
+        .sheet(isPresented: $isOptionGroupModalShown) {
+            OptionGroupCreationForm(options: $options)
+        }
+    }
+}
+
+struct OptionGroupCreationForm: View {
+    @Environment(\.presentationMode) var presentationMode
+
+    @State var title: String = ""
+    @Binding var options: [ProductOption]
+    @State var userOptions = [String]()
+    @State var userPrices = [String]()
+
+    @State private var showAlert = false
+    @State private var alertMessage = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Create option group")
+                .font(.appTitle)
+            PSTextField(text: $title,
+                        title: "Option Group Title",
+                        placeholder: "Enter option group title")
+
+            ForEach(0..<userOptions.count, id: \.self) { index in
+                HStack {
+                    PSTextField(text: $userOptions[index],
+                                title: "Option \(index + 1)",
+                                placeholder: "Enter option name")
+                    PSTextField(text: $userPrices[index],
+                                title: "Price",
+                                placeholder: "Enter option price")
+                        .keyboardType(.numberPad)
+                }
+            }
+
+            Button(action: {
+                userOptions.append("")
+                userPrices.append("")
+            }, label: {
+                Text("\(Image(systemName: "plus.circle")) Add option")
+            })
+            .padding(.vertical)
+
+            Spacer()
+            PSButton(title: "Save") {
+                guard !title.isEmpty else {
+                    alertMessage = "Please enter a title for option group!"
+                    showAlert = true
+                    return
+                }
+                guard !userOptions.allSatisfy({ $0.isEmpty }),
+                      !userPrices.allSatisfy({ $0.isEmpty }) else {
+                    alertMessage = "Please enter all options/prices"
+                    showAlert = true
+                    return
+                }
+                options.append(createOptionGroupFrom(title: title,
+                                                     userOptions: userOptions,
+                                                     userPrices: userPrices))
+                presentationMode.wrappedValue.dismiss()
+            }.buttonStyle(FillButtonStyle())
+            PSButton(title: "Cancel") {
+                presentationMode.wrappedValue.dismiss()
+            }.buttonStyle(OutlineButtonStyle())
+        }
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text(alertMessage), dismissButton: .default(Text("Ok")))
+        }
+        .padding()
+        .frame(maxWidth: Constants.maxWidthIPad)
+    }
+
+    func createOptionGroupFrom(title: String, userOptions: [String], userPrices: [String]) -> ProductOption {
+        var choices = [ProductOptionChoice]()
+        for i in 0..<userOptions.count {
+            choices.append(ProductOptionChoice(description: userOptions[i],
+                                               cost: Double(userPrices[i]) ?? 0))
+        }
+        let option = ProductOption(title: title,
+                                   type: .selectOne,
+                                   optionChoices: choices)
+        return option
+    }
+}
+
+struct OptionGroupView: View {
+
+    @State var optionGroup: ProductOption
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(optionGroup.title)
+                .font(.appHeadline)
+            ForEach(optionGroup.optionChoices, id: \.self) { choice in
+                HStack {
+                    Text("\(choice.description)")
+                        .font(.appBody)
+                    Spacer()
+                    Text("$\(choice.cost, specifier: "%.2f")")
+                        .font(.appCaption)
+                }
+            }
+        }
+        .padding()
     }
 }

--- a/PocketShop/Views/ShopViews/ShopProductFormView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductFormView.swift
@@ -160,7 +160,7 @@ struct CategoryPickerSection: View {
 
     var body: some View {
         HStack {
-            VStack {
+            VStack(alignment: .leading) {
                 Text("Select Product Category".uppercased())
                     .font(.appSmallCaption)
 
@@ -174,5 +174,6 @@ struct CategoryPickerSection: View {
             }
             Spacer()
         }
+        .frame(maxWidth: Constants.maxWidthIPad)
     }
 }


### PR DESCRIPTION
- [X] Vendor side option creation
- [x] Customer side option selection 
  - Edited formula for calculating cost of products, taking into account options

I used a bit of a hack to get options and radio buttons working. Brief sketch of what happens:
1. Every `Product` has `[ProductOption]`, where each `ProductOption` contains `[ProductOptionChoice]`, and each choice has `title` and `cost`. In pseudocode, this can be represented as:
```
["Chili": [("none", 0), ("more", 1), ("triple", 2)],
"Cheese": [("none",0), ("extra", 2)]]    <- this is an [ProductOption] array
```
Which translates (in English) to: 
Option Group 1 ("Chili") has 3 options
Option Group 2 ("Cheese") has 2 options.

2. `PSRadioButtonGroup` takes in an array of options (`[String]`) for rendering. Each time an option is selected, we get a callback containing the index in the array, as well as the index of the parent option group.

Example: Selecting "Chili, triple" will return `(0, 2)` since Chili is the 0th option group and "triple" is the 2nd selection
Example: Selecting "Cheese, none" will return `(1, 0)` since Cheese is the 1st option group and "none" is the 0th selection

3. Using these indices, we are able to calculate the choices that the user has selected, and reconstruct a `[ProductOptionChoice]` array using the indices