### PR TITLE
Fix environment object not being passed into product creation form

### DIFF
--- a/PocketShop/Views/ShopViews/ShopProductsView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductsView.swift
@@ -59,6 +59,7 @@ struct ShopProductsView: View {
             switch item {
             case .addProduct:
                 ShopProductFormView()
+                    .environmentObject(viewModel)
             case .editShop:
                 ShopEditFormView(viewModel: viewModel, shop: shop)
             }


### PR DESCRIPTION
Product creation form was facing issues because view model was not being passed as an environment object.

`Sheet`s are not child views of parent views, so we have to specifically
declare environment objects for sheets as well.