### PR TITLE
Implement product stock status frontend

### DIFF
--- a/PocketShop.xcodeproj/project.pbxproj
+++ b/PocketShop.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		DF0BA5E92808818200D58696 /* CustomerLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0BA5E82808818200D58696 /* CustomerLocationView.swift */; };
 		DF0BA5EB2808890F00D58696 /* ShopListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0BA5EA2808890F00D58696 /* ShopListView.swift */; };
 		DF0BA5EF2808BFFD00D58696 /* ProductDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0BA5EE2808BFFD00D58696 /* ProductDetailView.swift */; };
+		DF0BA5F12809862D00D58696 /* ShopProductListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0BA5F02809862D00D58696 /* ShopProductListView.swift */; };
 		DF34150427F9C56400CC945C /* ShopOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3414FD27F9C56300CC945C /* ShopOrderScreen.swift */; };
 		DF34150527F9C56400CC945C /* ShopProductFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3414FE27F9C56300CC945C /* ShopProductFormView.swift */; };
 		DF34150627F9C56400CC945C /* ShopHomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3414FF27F9C56300CC945C /* ShopHomeScreen.swift */; };
@@ -207,6 +208,7 @@
 		DF0BA5E82808818200D58696 /* CustomerLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerLocationView.swift; sourceTree = "<group>"; };
 		DF0BA5EA2808890F00D58696 /* ShopListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopListView.swift; sourceTree = "<group>"; };
 		DF0BA5EE2808BFFD00D58696 /* ProductDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDetailView.swift; sourceTree = "<group>"; };
+		DF0BA5F02809862D00D58696 /* ShopProductListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopProductListView.swift; sourceTree = "<group>"; };
 		DF3414FD27F9C56300CC945C /* ShopOrderScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShopOrderScreen.swift; path = PocketShop/Views/ShopViews/ShopOrderScreen.swift; sourceTree = SOURCE_ROOT; };
 		DF3414FE27F9C56300CC945C /* ShopProductFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShopProductFormView.swift; path = PocketShop/Views/ShopViews/ShopProductFormView.swift; sourceTree = SOURCE_ROOT; };
 		DF3414FF27F9C56300CC945C /* ShopHomeScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShopHomeScreen.swift; path = PocketShop/Views/ShopViews/ShopHomeScreen.swift; sourceTree = SOURCE_ROOT; };
@@ -517,6 +519,7 @@
 				DF34150227F9C56400CC945C /* ShopProductEditFormView.swift */,
 				DF3414FE27F9C56300CC945C /* ShopProductFormView.swift */,
 				DF34150127F9C56300CC945C /* ShopProductsView.swift */,
+				DF0BA5F02809862D00D58696 /* ShopProductListView.swift */,
 			);
 			path = ShopViews;
 			sourceTree = "<group>";
@@ -777,6 +780,7 @@
 				02AD41DD27DEFD0B00F44822 /* Constants.swift in Sources */,
 				022EA8B927E4D437003F4E3C /* ShopViewRouter.swift in Sources */,
 				02AD421E27DF1D3100F44822 /* CustomerViewRouter.swift in Sources */,
+				DF0BA5F12809862D00D58696 /* ShopProductListView.swift in Sources */,
 				DF34150827F9C56400CC945C /* ShopProductsView.swift in Sources */,
 				ADAD28F827F4A0F600CDE510 /* DBCart.swift in Sources */,
 				DF0BA5EF2808BFFD00D58696 /* ProductDetailView.swift in Sources */,

--- a/PocketShop/ViewModels/VendorViewModel.swift
+++ b/PocketShop/ViewModels/VendorViewModel.swift
@@ -66,14 +66,22 @@ final class VendorViewModel: ObservableObject {
         products.remove(atOffsets: positions)
     }
 
-    func setProductOutOfStock(product: Product) {
+    func toggleProductStockStatus(product: Product) {
+        if product.isOutOfStock {
+            setProductInStock(product: product)
+        } else {
+            setProductOutOfStock(product: product)
+        }
+    }
+
+    private func setProductOutOfStock(product: Product) {
         DatabaseInterface.db.setProductToOutOfStock(shopId: product.shopId, productId: product.id)
         for otherProduct in products where otherProduct.isComboMeal && otherProduct.subProductIds.contains(product.id) {
             DatabaseInterface.db.setProductToOutOfStock(shopId: product.shopId, productId: otherProduct.id)
         }
     }
 
-    func setProductInStock(product: Product) {
+    private func setProductInStock(product: Product) {
         DatabaseInterface.db.setProductToInStock(shopId: product.shopId, productId: product.id)
         if product.isComboMeal {
             for subProductId in product.subProductIds {

--- a/PocketShop/Views/CustomerViews/CustomerShopView.swift
+++ b/PocketShop/Views/CustomerViews/CustomerShopView.swift
@@ -61,9 +61,9 @@ struct ProductPreview: View {
 
     var body: some View {
         VStack {
-            if isClosed {
+            if isClosed || product.isOutOfStock {
                 ProductListView(product: product).environmentObject(viewModel)
-                    .opacity(0.5)
+                    .opacity(isClosed ? 0.5 : 1)
             } else {
                 NavigationLink(destination: ProductDetailView(product: product)) {
                     ProductListView(product: product).environmentObject(viewModel)

--- a/PocketShop/Views/CustomerViews/ProductListView.swift
+++ b/PocketShop/Views/CustomerViews/ProductListView.swift
@@ -22,6 +22,7 @@ struct ProductListView: View {
                     .padding(.leading)
             }
         }
+        .opacity(product.isOutOfStock ? 0.5 : 1)
     }
 }
 

--- a/PocketShop/Views/CustomerViews/ProductsScrollView.swift
+++ b/PocketShop/Views/CustomerViews/ProductsScrollView.swift
@@ -57,8 +57,10 @@ private struct HorizontalScrollSection: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 ForEach(products) { product in
-                    NavigationLink(destination: ProductDetailView(product: product).environmentObject(viewModel)) {
-                        ProductSummaryView(product: product).environmentObject(viewModel)
+                    if !product.isOutOfStock {
+                        NavigationLink(destination: ProductDetailView(product: product).environmentObject(viewModel)) {
+                            ProductSummaryView(product: product).environmentObject(viewModel)
+                        }
                     }
                 }
             }

--- a/PocketShop/Views/ShopViews/ShopProductListView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductListView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ShopProductListView: View {
+    var product: Product
+
+    var body: some View {
+        HStack {
+            ProductListView(product: product)
+            Spacer()
+            ToggleProductStockStatusButton(product: product)
+        }
+    }
+}
+
+struct ToggleProductStockStatusButton: View {
+    @EnvironmentObject var viewModel: VendorViewModel
+    var product: Product
+
+    var body: some View {
+        Text(product.isOutOfStock
+             ? "In Stock \(Image(systemName: "checkmark"))"
+             : "Out of Stock \(Image(systemName: "nosign"))")
+            .foregroundColor(Color.accent)
+            .font(.appCaption)
+            .padding()
+            .overlay(
+                RoundedRectangle(cornerRadius: 4.0)
+                    .stroke(Color.accent, lineWidth: 1)
+            )
+            .onTapGesture {
+                viewModel.toggleProductStockStatus(product: product)
+            }
+    }
+}

--- a/PocketShop/Views/ShopViews/ShopProductsView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductsView.swift
@@ -34,7 +34,7 @@ struct ShopProductsView: View {
                                 if product.shopCategory?.title == shopCategory.title {
                                     NavigationLink(destination: ShopProductEditFormView(viewModel: viewModel,
                                                                                         product: product)) {
-                                        ProductListView(product: product)
+                                        ShopProductListView(product: product)
                                     }
                                 }
                             }


### PR DESCRIPTION
Implemented the following changes (resolves #52 ):
Shop:
- Can set products to in-stock/out-of-stock from their home page
- Out-of-stock products will be greyed out on their home page

Customer:
- Out-of-stock products no longer appear in the home page scroll view (regardless of search results)
- Upon navigating to a shop, any out-of-stock shop product is greyed out and cannot be tapped on to order
- On favourites page, any out-of-stock shop product is greyed out and cannot be tapped on to order