### PR TITLE
Edit Cart + Fix from Sprint 2

### DIFF
--- a/PocketShop/ViewModels/CustomerViewModel.swift
+++ b/PocketShop/ViewModels/CustomerViewModel.swift
@@ -34,12 +34,12 @@ final class CustomerViewModel: ObservableObject {
     func cancelOrder(orderId: String) {
         DatabaseInterface.db.cancelOrder(id: orderId)
     }
-    
+
     func getProductFor(cartProduct: CartProduct) -> Product {
         guard let product = products.first(where: { $0.id == cartProduct.productId }) else {
             fatalError("No product \(cartProduct.productId) exists!")
         }
-        
+
         return product
     }
 
@@ -58,14 +58,15 @@ final class CustomerViewModel: ObservableObject {
                                                   productOptionChoices: choices, quantity: quantity)
         }
     }
-    
+
     func editCartProduct(_ cartProduct: CartProduct, product: Product, quantity: Int, choices: [ProductOptionChoice]) {
         guard let customerId = self.customer?.id else {
             fatalError("No customer")
         }
-        
+
         DatabaseInterface.db.removeProductFromCart(userId: customerId, cartProduct: cartProduct)
-        DatabaseInterface.db.addProductToCart(userId: customerId, product: product, productOptionChoices: choices, quantity: quantity)
+        DatabaseInterface.db.addProductToCart(userId: customerId, product: product,
+                                              productOptionChoices: choices, quantity: quantity)
     }
 
     func makeOrderFromCart() -> [(CartValidationError, CartProduct)]? {

--- a/PocketShop/ViewModels/CustomerViewModel.swift
+++ b/PocketShop/ViewModels/CustomerViewModel.swift
@@ -34,6 +34,14 @@ final class CustomerViewModel: ObservableObject {
     func cancelOrder(orderId: String) {
         DatabaseInterface.db.cancelOrder(id: orderId)
     }
+    
+    func getProductFor(cartProduct: CartProduct) -> Product {
+        guard let product = products.first(where: { $0.id == cartProduct.productId }) else {
+            fatalError("No product \(cartProduct.productId) exists!")
+        }
+        
+        return product
+    }
 
     func addProductToCart(_ product: Product, quantity: Int, choices: [ProductOptionChoice]) {
         guard let customerId = customer?.id else {
@@ -49,6 +57,15 @@ final class CustomerViewModel: ObservableObject {
             DatabaseInterface.db.addProductToCart(userId: customerId, product: product,
                                                   productOptionChoices: choices, quantity: quantity)
         }
+    }
+    
+    func editCartProduct(_ cartProduct: CartProduct, product: Product, quantity: Int, choices: [ProductOptionChoice]) {
+        guard let customerId = self.customer?.id else {
+            fatalError("No customer")
+        }
+        
+        DatabaseInterface.db.removeProductFromCart(userId: customerId, cartProduct: cartProduct)
+        DatabaseInterface.db.addProductToCart(userId: customerId, product: product, productOptionChoices: choices, quantity: quantity)
     }
 
     func makeOrderFromCart() -> [(CartValidationError, CartProduct)]? {

--- a/PocketShop/ViewModels/OrderViewModel.swift
+++ b/PocketShop/ViewModels/OrderViewModel.swift
@@ -46,7 +46,22 @@ struct OrderViewModel {
     }
 
     var showCancel: Bool {
-        status == .pending
+        status == .pending || status == .cancelled
+    }
+    
+    var buttonText: String {
+        switch status {
+        case .pending:
+            return "Accept"
+        case .accepted:
+            return "Prepare"
+        case .preparing:
+            return "Ready"
+        case .ready:
+            return "Collected"
+        default:
+            return ""
+        }
     }
 
     private let dateFormatter = DateFormatter()

--- a/PocketShop/ViewModels/OrderViewModel.swift
+++ b/PocketShop/ViewModels/OrderViewModel.swift
@@ -48,7 +48,7 @@ struct OrderViewModel {
     var showCancel: Bool {
         status == .pending
     }
-    
+
     var buttonText: String {
         switch status {
         case .pending:

--- a/PocketShop/ViewModels/OrderViewModel.swift
+++ b/PocketShop/ViewModels/OrderViewModel.swift
@@ -33,7 +33,7 @@ struct OrderViewModel {
     }
 
     var isHistory: Bool {
-        status == .collected
+        status == .collected || status == .cancelled
     }
 
     var ringColor: Color {
@@ -46,7 +46,7 @@ struct OrderViewModel {
     }
 
     var showCancel: Bool {
-        status == .pending || status == .cancelled
+        status == .pending
     }
     
     var buttonText: String {

--- a/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
@@ -111,7 +111,7 @@ struct TrashAndEditCartItemButton: View {
             }
         }
         .frame(width: 100)
-        
+
         Image(systemName: "trash")
             .resizable()
             .frame(width: 24, height: 24)

--- a/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
@@ -19,7 +19,7 @@ struct CustomerCartScreen: View {
                             .bold()
 
                         PSButton(title: "Order") {
-                            viewModel.makeOrder()
+                            viewModel.confirmOrder()
                         }
                         .buttonStyle(FillButtonStyle())
                     }
@@ -30,11 +30,35 @@ struct CustomerCartScreen: View {
             .padding()
         }
         .navigationViewStyle(StackNavigationViewStyle())
-        .alert(isPresented: $viewModel.showError) {
-            Alert(title: Text("Oops"),
-                  message: Text("\(viewModel.errorMessage)"),
-                  dismissButton: .default(Text("OK")))
+        .alert(isPresented: $viewModel.showAlert) {
+            switch viewModel.activeAlert {
+            case .showEmptyCart:
+                return emptyCartAlert()
+            case .showConfirmOrder:
+                return makeOrderAlert()
+            case .showError:
+                return errorAlert()
+            }
         }
+    }
+
+    private func emptyCartAlert() -> Alert {
+        Alert(title: Text("Unable to Order"),
+              message: Text("Unable to make order since your cart is empty"),
+              dismissButton: .default(Text("OK")))
+    }
+
+    private func makeOrderAlert() -> Alert {
+        Alert(title: Text("Confirm Order"),
+              message: Text("Confirm to order items in cart?"),
+              primaryButton: .default(Text("Confirm")) { viewModel.makeOrder() },
+              secondaryButton: .destructive(Text("Cancel")))
+    }
+
+    private func errorAlert() -> Alert {
+        Alert(title: Text("Oops"),
+              message: Text("\(viewModel.errorMessage)"),
+              dismissButton: .default(Text("OK")))
     }
 
     @ViewBuilder
@@ -132,10 +156,15 @@ struct TrashAndEditCartItemButton: View {
 }
 
 extension CustomerCartScreen {
+    enum ActiveAlert {
+        case showError, showEmptyCart, showConfirmOrder
+    }
+
     class ViewModel: ObservableObject {
         @ObservedObject var customerViewModel: CustomerViewModel
         @Published var cartProducts: [CartProduct] = []
-        @Published var showError = false
+        @Published var showAlert = false
+        @Published var activeAlert: ActiveAlert = .showError
         @Published var errorMessage = ""
 
         var total: Double {
@@ -147,6 +176,16 @@ extension CustomerCartScreen {
         init(customerViewModel: CustomerViewModel) {
             self.customerViewModel = customerViewModel
             self.cartProducts = customerViewModel.cart
+        }
+
+        func confirmOrder() {
+            if cartProducts.isEmpty {
+                activeAlert = .showEmptyCart
+            } else {
+                activeAlert = .showConfirmOrder
+            }
+
+            showAlert.toggle()
         }
 
         func makeOrder() {
@@ -172,7 +211,9 @@ extension CustomerCartScreen {
             case .shopClosed:
                 errorMessage = "Unable to order \(cartProduct.productName) since \(cartProduct.shopName) is closed :("
             }
-            showError = true
+
+            activeAlert = .showError
+            showAlert.toggle()
         }
 
         func removeCartProduct(_ cartProduct: CartProduct) {

--- a/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
+++ b/PocketShop/Views/CustomerViews/CustomerCartScreen.swift
@@ -60,7 +60,7 @@ struct CustomerCartScreen: View {
 
                 Spacer()
 
-                TrashCartItemButton(cartProduct: cartProduct)
+                TrashAndEditCartItemButton(cartProduct: cartProduct)
             }
         }
         .padding()
@@ -95,12 +95,23 @@ struct CartItemDescription: View {
     }
 }
 
-struct TrashCartItemButton: View {
+struct TrashAndEditCartItemButton: View {
     @EnvironmentObject var viewModel: CustomerViewModel
     var cartProduct: CartProduct
     @State private var showConfirmDelete = false
+    @State private var navigateToProductDetail = false
 
     var body: some View {
+        NavigationLink(destination:
+                        ProductDetailView(product: viewModel.getProductFor(cartProduct: cartProduct),
+                                          cartProduct: cartProduct),
+                        isActive: $navigateToProductDetail) {
+            PSButton(title: "Edit") {
+                navigateToProductDetail.toggle()
+            }
+        }
+        .frame(width: 100)
+        
         Image(systemName: "trash")
             .resizable()
             .frame(width: 24, height: 24)

--- a/PocketShop/Views/CustomerViews/ProductDetailView.swift
+++ b/PocketShop/Views/CustomerViews/ProductDetailView.swift
@@ -3,6 +3,16 @@ import SwiftUI
 struct ProductDetailView: View {
     @EnvironmentObject var viewModel: CustomerViewModel
     var product: Product
+    var cartProduct: CartProduct?
+    
+    init(product: Product) {
+        self.product = product
+    }
+    
+    init(product: Product, cartProduct: CartProduct) {
+        self.product = product
+        self.cartProduct = cartProduct
+    }
 
     var body: some View {
         VStack {
@@ -29,7 +39,7 @@ struct ProductDetailView: View {
                 .font(.appBody)
                 .fontWeight(.semibold)
 
-            ProductOrderBar(product: product)
+            ProductOrderBar(product: product, cartProduct: cartProduct)
         }
         .toolbar {
             FavouritesButton(itemId: product.id)

--- a/PocketShop/Views/CustomerViews/ProductDetailView.swift
+++ b/PocketShop/Views/CustomerViews/ProductDetailView.swift
@@ -4,11 +4,11 @@ struct ProductDetailView: View {
     @EnvironmentObject var viewModel: CustomerViewModel
     var product: Product
     var cartProduct: CartProduct?
-    
+
     init(product: Product) {
         self.product = product
     }
-    
+
     init(product: Product, cartProduct: CartProduct) {
         self.product = product
         self.cartProduct = cartProduct

--- a/PocketShop/Views/CustomerViews/ProductOrderBar.swift
+++ b/PocketShop/Views/CustomerViews/ProductOrderBar.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 class CustomerChoices: ObservableObject {
     @Published var choices = [ProductOptionChoice]()
-    
+
     init() {}
-    
+
     init(choices: [ProductOptionChoice]) {
         self.choices = choices
     }
@@ -17,15 +17,15 @@ struct ProductOrderBar: View {
     @ObservedObject var choices = CustomerChoices()
     var product: Product
     var cartProduct: CartProduct?
-    
+
     init(product: Product) {
         self.product = product
     }
-    
+
     init(product: Product, cartProduct: CartProduct?) {
         self.product = product
         self.cartProduct = cartProduct
-        
+
         // If it has cartProduct, then we "edit cart" instead of "add to cart"
         if let cartProduct = cartProduct {
             self._quantity = State(initialValue: cartProduct.quantity)
@@ -66,16 +66,15 @@ struct ProductOptionsGroup: View {
 
         for i in 0..<availableOptions.count {
             let availableOption = availableOptions[i]
-            
+
             for j in 0..<availableOption.optionChoices.count {
                 let optionChoice = availableOption.optionChoices[j]
-                
+
                 if selectedOptions.choices.contains(optionChoice) {
                     tempIndices[i] = j
                 }
             }
         }
-
 
         self._selectedIndices = State(initialValue: tempIndices)
     }
@@ -111,7 +110,7 @@ struct ProductOptionsGroup: View {
             tempChoices.append(availableOptions[i].optionChoices[choiceIndex])
         }
         selectedOptions.choices = tempChoices
-        
+
     }
 }
 
@@ -158,7 +157,7 @@ struct PriceAndOrderButton: View {
             // Price and order button
             Text(String(format: "Price: $%.2f", price))
                 .font(.appHeadline)
-            
+
             if cartProduct == nil {
                 PSButton(title: "Add to Cart") {
                     addToCart()
@@ -190,7 +189,7 @@ struct PriceAndOrderButton: View {
                                            quantity: quantity,
                                            choices: selectedOptions.choices)
     }
-    
+
     func editCartProduct() {
         guard let cartProduct = cartProduct else {
             return
@@ -201,7 +200,7 @@ struct PriceAndOrderButton: View {
                                           quantity: quantity,
                                           choices: selectedOptions.choices)
     }
-    
+
     private func getAlert() -> Alert {
         if cartProduct == nil {
             return getAddToCartAlert()
@@ -209,7 +208,7 @@ struct PriceAndOrderButton: View {
             return getEditCartProductAlert()
         }
     }
-    
+
     private func getAddToCartAlert() -> Alert {
         Alert(title: Text("Added to cart"),
               message: Text("\(product.name) has been added to Cart."),
@@ -217,7 +216,7 @@ struct PriceAndOrderButton: View {
                 presentationMode.wrappedValue.dismiss()
               })
     }
-    
+
     private func getEditCartProductAlert() -> Alert {
         Alert(title: Text("Edited cart product"),
               message: Text("\(product.name) has been edited in your Cart."),

--- a/PocketShop/Views/ShopViews/ShopOrderScreen.swift
+++ b/PocketShop/Views/ShopViews/ShopOrderScreen.swift
@@ -65,8 +65,8 @@ struct ShopOrderScreen: View {
             StatusRing(order: order)
 
             Spacer()
-            
-            if (!order.isHistory) {
+
+            if !order.isHistory {
                 ToggleOrderStatusButton(order: order)
             }
 
@@ -89,7 +89,7 @@ struct ShopOrderScreen: View {
         .frame(width: 100)
         .frame(minHeight: 128)
     }
-    
+
     @ViewBuilder
     func ToggleOrderStatusButton(order: OrderViewModel) -> some View {
         PSButton(title: order.buttonText) {
@@ -102,7 +102,7 @@ struct ShopOrderScreen: View {
             guard let selectedOrder = self.selectedOrder else {
                 fatalError("Order does not exist")
             }
-            
+
             return getAlertForOrder(selectedOrder)
         }
     }
@@ -189,6 +189,8 @@ extension ShopOrderScreen {
         func setFilterCurrent() {
             filteredOrders = vendorViewModel.orders.filter { order in
                 order.status != .collected && order.status != .cancelled
+            }.sorted {
+                $0.date < $1.date
             }.map {
                 OrderViewModel(order: $0)
             }
@@ -197,6 +199,8 @@ extension ShopOrderScreen {
         func setFilterHistory() {
             filteredOrders = vendorViewModel.orders.filter { order in
                 order.status == .collected || order.status == .cancelled
+            }.sorted {
+                $0.date > $1.date
             }.map {
                 OrderViewModel(order: $0)
             }

--- a/PocketShop/Views/ShopViews/ShopOrderScreen.swift
+++ b/PocketShop/Views/ShopViews/ShopOrderScreen.swift
@@ -62,9 +62,13 @@ struct ShopOrderScreen: View {
 
             Spacer()
 
-            InteractableStatusRing(order: order)
+            StatusRing(order: order)
 
             Spacer()
+            
+            if (!order.isHistory) {
+                ToggleOrderStatusButton(order: order)
+            }
 
             if order.showCancel {
                 PSButton(title: "Cancel") {
@@ -85,22 +89,27 @@ struct ShopOrderScreen: View {
         .frame(width: 100)
         .frame(minHeight: 128)
     }
+    
+    @ViewBuilder
+    func ToggleOrderStatusButton(order: OrderViewModel) -> some View {
+        PSButton(title: order.buttonText) {
+            showConfirmation.toggle()
+            selectedOrder = order
+        }
+        .frame(height: 64)
+        .buttonStyle(FillButtonStyle())
+        .alert(isPresented: $showConfirmation) {
+            guard let selectedOrder = self.selectedOrder else {
+                fatalError("Order does not exist")
+            }
+            
+            return getAlertForOrder(selectedOrder)
+        }
+    }
 
     @ViewBuilder
-    func InteractableStatusRing(order: OrderViewModel) -> some View {
+    func StatusRing(order: OrderViewModel) -> some View {
         RingView(color: order.ringColor, text: order.status.toString())
-            .onTapGesture {
-                showConfirmation.toggle()
-                selectedOrder = order
-            }
-            .alert(isPresented: $showConfirmation) {
-                guard let selectedOrder = self.selectedOrder else {
-                    // TODO: show user-friendly error message
-                    fatalError("Order does not exist")
-                }
-
-                return getAlertForOrder(selectedOrder)
-            }
     }
 
     private func getCancelAlertForOrder(_ order: OrderViewModel) -> Alert {


### PR DESCRIPTION
Changes made:
- Extended `ProductDetailView` and `ProductOrderBar` so that it can edit existing product. Not sure there might be a good way to initialize choices in `ProductOrderBar`
- The ring in `ShopOrderScreen` is no longer intractable
- Updating order status (for vendor) can be done via button
- Order will be sorted based on the date. "Current" will show order increasing in date, whilst history will show order decreasing in date
- Confirmation alert will show when user make order from cart
- Empty cart alert will show if order is made when no products in the cart

Fixes: #53 