### PR TITLE
Implement Product Tags

### DIFF
--- a/PocketShop.xcodeproj/project.pbxproj
+++ b/PocketShop.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		DF0BA5EB2808890F00D58696 /* ShopListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0BA5EA2808890F00D58696 /* ShopListView.swift */; };
 		DF0BA5EF2808BFFD00D58696 /* ProductDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0BA5EE2808BFFD00D58696 /* ProductDetailView.swift */; };
 		DF0BA5F12809862D00D58696 /* ShopProductListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0BA5F02809862D00D58696 /* ShopProductListView.swift */; };
+		DF0BA5F3280AB7BF00D58696 /* PSMultiLineTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0BA5F2280AB7BF00D58696 /* PSMultiLineTextField.swift */; };
 		DF34150427F9C56400CC945C /* ShopOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3414FD27F9C56300CC945C /* ShopOrderScreen.swift */; };
 		DF34150527F9C56400CC945C /* ShopProductFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3414FE27F9C56300CC945C /* ShopProductFormView.swift */; };
 		DF34150627F9C56400CC945C /* ShopHomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3414FF27F9C56300CC945C /* ShopHomeScreen.swift */; };
@@ -209,6 +210,7 @@
 		DF0BA5EA2808890F00D58696 /* ShopListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopListView.swift; sourceTree = "<group>"; };
 		DF0BA5EE2808BFFD00D58696 /* ProductDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDetailView.swift; sourceTree = "<group>"; };
 		DF0BA5F02809862D00D58696 /* ShopProductListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopProductListView.swift; sourceTree = "<group>"; };
+		DF0BA5F2280AB7BF00D58696 /* PSMultiLineTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PSMultiLineTextField.swift; sourceTree = "<group>"; };
 		DF3414FD27F9C56300CC945C /* ShopOrderScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShopOrderScreen.swift; path = PocketShop/Views/ShopViews/ShopOrderScreen.swift; sourceTree = SOURCE_ROOT; };
 		DF3414FE27F9C56300CC945C /* ShopProductFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShopProductFormView.swift; path = PocketShop/Views/ShopViews/ShopProductFormView.swift; sourceTree = SOURCE_ROOT; };
 		DF3414FF27F9C56300CC945C /* ShopHomeScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShopHomeScreen.swift; path = PocketShop/Views/ShopViews/ShopHomeScreen.swift; sourceTree = SOURCE_ROOT; };
@@ -338,6 +340,7 @@
 			children = (
 				DF67101D27DE769E002C5AE0 /* PSSearchBarView.swift */,
 				02AD423427DF28FD00F44822 /* PSTextField.swift */,
+				DF0BA5F2280AB7BF00D58696 /* PSMultiLineTextField.swift */,
 				02AD423C27DF293A00F44822 /* PSSecureField.swift */,
 				02AD424127DF294C00F44822 /* PSButton.swift */,
 				2B786B4927E33F1600834CA4 /* RingView.swift */,
@@ -757,6 +760,7 @@
 				AD15B3A127E46C9E00513809 /* DBProducts.swift in Sources */,
 				02AD422C27DF1FC700F44822 /* LoginViewModel.swift in Sources */,
 				ADAD9F2527DDDDD700DE0EE7 /* AuthError.swift in Sources */,
+				DF0BA5F3280AB7BF00D58696 /* PSMultiLineTextField.swift in Sources */,
 				02AD425F27E07F2800F44822 /* PSRadioButtonGroup.swift in Sources */,
 				ADAD28FC2801834900CDE510 /* Location.swift in Sources */,
 				ADAD28F627F4A0D400CDE510 /* CartProductSchema.swift in Sources */,

--- a/PocketShop/Core/Components/PSMultiLineTextField.swift
+++ b/PocketShop/Core/Components/PSMultiLineTextField.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct PSMultiLineTextField: View {
+    var groupTitle: String
+    var fieldTitle: String
+    @Binding var fields: [String]
+
+    var body: some View {
+        Text(groupTitle.uppercased())
+            .font(.appSmallCaption)
+
+        ForEach(0..<fields.count, id: \.self) { index in
+            HStack {
+                PSTextField(text: Binding(get: { fields[index] },
+                                          set: { fields[index] = $0 }),
+                            title: "\(fieldTitle) \(index + 1)",
+                            placeholder: "\(fieldTitle) \(index + 1)")
+
+                Button(action: {
+                    fields.remove(at: index)
+                }, label: {
+                    Image(systemName: "minus.circle")
+                        .foregroundColor(Color.red7)
+                }).padding(.top)
+            }
+        }
+
+        Button(action: {
+            fields.append("")
+        }, label: {
+            Text("\(Image(systemName: "plus.circle")) Add new \(fieldTitle.lowercased())")
+        })
+        .padding(.vertical)
+    }
+}

--- a/PocketShop/ViewModels/CustomerViewModel.swift
+++ b/PocketShop/ViewModels/CustomerViewModel.swift
@@ -312,10 +312,12 @@ extension CustomerViewModel {
         } else {
             return products.filter {
                 let productNameMatches = $0.name.localizedCaseInsensitiveContains(searchText)
+                let productTagMatches = $0.tags.contains(where: { $0.tag.localizedCaseInsensitiveContains(searchText) })
                 let productShopNameMatches = $0.shopName.localizedCaseInsensitiveContains(searchText)
                 let productShopLocationNameMatches = getLocationNameFromShopId(shopId: $0.shopId)
                     .localizedCaseInsensitiveContains(searchText)
-                return productNameMatches || productShopNameMatches || productShopLocationNameMatches
+                return productNameMatches || productTagMatches
+                || productShopNameMatches || productShopLocationNameMatches
             }
         }
     }
@@ -326,11 +328,16 @@ extension CustomerViewModel {
         } else {
             return shops.filter { shop in
                 let shopNameMatches = shop.name.localizedCaseInsensitiveContains(searchText)
-                let matchingProducts = shop.soldProducts.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
-                let shopAnyProductNameMatches = !matchingProducts.isEmpty
+                let shopAnyProductNameMatches = shop.soldProducts.contains(where: {
+                    $0.name.localizedCaseInsensitiveContains(searchText)
+                })
+                let shopAnyProductTagMatches = shop.soldProducts.contains(where: {
+                    $0.tags.contains(where: { $0.tag.localizedCaseInsensitiveContains(searchText) })
+                })
                 let shopLocationNameMatches = getLocationNameFromLocationId(locationId: shop.locationId)
                     .localizedCaseInsensitiveContains(searchText)
-                return shopNameMatches || shopAnyProductNameMatches || shopLocationNameMatches
+                return shopNameMatches || shopAnyProductNameMatches
+                || shopAnyProductTagMatches || shopLocationNameMatches
             }
         }
     }
@@ -341,18 +348,16 @@ extension CustomerViewModel {
         } else {
             return locations.filter { location in
                 let locationNameMatches = location.name.localizedCaseInsensitiveContains(searchText)
-                let matchingShops = shops.filter {
+                let locationAnyShopMatches = shops.contains(where: {
                     $0.locationId == location.id && $0.name.localizedCaseInsensitiveContains(searchText)
-                }
-                let locationAnyShopMatches = !matchingShops.isEmpty
-                let shopsWithMatchingProducts = shops.filter { shop in
-                    let matchingShopProducts = shop.soldProducts.filter {
+                })
+                let locationAnyShopProductMatches = shops.contains(where: { shop in
+                    shop.locationId == location.id && shop.soldProducts.contains(where: {
                         $0.name.localizedCaseInsensitiveContains(searchText)
-                    }
-                    return shop.locationId == location.id && !matchingShopProducts.isEmpty
-                }
-                let locationAnyShopProductNameMatches = !shopsWithMatchingProducts.isEmpty
-                return locationNameMatches || locationAnyShopMatches || locationAnyShopProductNameMatches
+                        || $0.tags.contains(where: { $0.tag.localizedCaseInsensitiveContains(searchText) })
+                    })
+                })
+                return locationNameMatches || locationAnyShopMatches || locationAnyShopProductMatches
             }
         }
     }

--- a/PocketShop/ViewModels/VendorViewModel.swift
+++ b/PocketShop/ViewModels/VendorViewModel.swift
@@ -74,22 +74,6 @@ final class VendorViewModel: ObservableObject {
         }
     }
 
-    private func setProductOutOfStock(product: Product) {
-        DatabaseInterface.db.setProductToOutOfStock(shopId: product.shopId, productId: product.id)
-        for otherProduct in products where otherProduct.isComboMeal && otherProduct.subProductIds.contains(product.id) {
-            DatabaseInterface.db.setProductToOutOfStock(shopId: product.shopId, productId: otherProduct.id)
-        }
-    }
-
-    private func setProductInStock(product: Product) {
-        DatabaseInterface.db.setProductToInStock(shopId: product.shopId, productId: product.id)
-        if product.isComboMeal {
-            for subProductId in product.subProductIds {
-                DatabaseInterface.db.setProductToInStock(shopId: product.shopId, productId: subProductId)
-            }
-        }
-    }
-
     func setAllProductsToInStock() {
         if let currentShop = currentShop {
             DatabaseInterface.db.setAllProductsInShopToInStock(shopId: currentShop.id)
@@ -207,6 +191,22 @@ final class VendorViewModel: ObservableObject {
                                 total: order.total)
 
         DatabaseInterface.db.editOrder(order: editedOrder)
+    }
+
+    private func setProductOutOfStock(product: Product) {
+        DatabaseInterface.db.setProductToOutOfStock(shopId: product.shopId, productId: product.id)
+        for otherProduct in products where otherProduct.isComboMeal && otherProduct.subProductIds.contains(product.id) {
+            DatabaseInterface.db.setProductToOutOfStock(shopId: product.shopId, productId: otherProduct.id)
+        }
+    }
+
+    private func setProductInStock(product: Product) {
+        DatabaseInterface.db.setProductToInStock(shopId: product.shopId, productId: product.id)
+        if product.isComboMeal {
+            for subProductId in product.subProductIds {
+                DatabaseInterface.db.setProductToInStock(shopId: product.shopId, productId: subProductId)
+            }
+        }
     }
 
     private func observeLocations() {

--- a/PocketShop/Views/CustomerViews/CustomerLocationView.swift
+++ b/PocketShop/Views/CustomerViews/CustomerLocationView.swift
@@ -71,13 +71,9 @@ struct ShopPreview: View {
 
     var body: some View {
         VStack {
-            if shop.isClosed {
+            NavigationLink(destination: CustomerShopView(shop: shop)) {
                 ShopListView(shop: shop).environmentObject(viewModel)
-                    .opacity(0.5)
-            } else {
-                NavigationLink(destination: CustomerShopView(shop: shop)) {
-                    ShopListView(shop: shop).environmentObject(viewModel)
-                }
+                    .opacity(shop.isClosed ? 0.5 : 1)
             }
         }
     }

--- a/PocketShop/Views/ShopViews/ShopFormView.swift
+++ b/PocketShop/Views/ShopViews/ShopFormView.swift
@@ -112,18 +112,9 @@ struct ShopTextFields: View {
                     title: "Shop Description",
                     placeholder: "Shop Description")
 
-        ForEach(0..<categories.count, id: \.self) { index in
-            PSTextField(text: $categories[index],
-                        title: "Shop Category \(index + 1)",
-                        placeholder: "Shop Category \(index + 1)")
-        }
-
-        Button(action: {
-            categories.append("")
-        }, label: {
-            Text("\(Image(systemName: "plus.circle")) Add new shop category")
-        })
-        .padding(.vertical)
+        PSMultiLineTextField(groupTitle: "Shop Categories",
+                             fieldTitle: "Shop Category",
+                             fields: $categories)
     }
 }
 

--- a/PocketShop/Views/ShopViews/ShopProductEditFormView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductEditFormView.swift
@@ -12,6 +12,7 @@ struct ShopProductEditFormView: View {
     @State private var image: UIImage?
     @State private var category: String = ""
     @State private var options = [ProductOption]()
+    @State private var tags = [String]()
 
     init(viewModel: VendorViewModel, product: Product) {
         self.product = product
@@ -21,6 +22,7 @@ struct ShopProductEditFormView: View {
         self._prepTime = State(initialValue: String(product.estimatedPrepTime))
         self._category = State(initialValue: product.shopCategory?.title ?? "")
         self._options = State(initialValue: product.options)
+        self._tags = State(initialValue: product.tags.map { $0.tag })
     }
 
     var body: some View {
@@ -29,8 +31,8 @@ struct ShopProductEditFormView: View {
                 Text("Edit product")
                     .font(.appTitle)
 
-                UserInputSegment(name: $name, price: $price, description: $description,
-                                 prepTime: $prepTime, category: $category, options: $options)
+                UserInputSegment(name: $name, price: $price, description: $description, prepTime: $prepTime,
+                                 category: $category, options: $options, tags: $tags)
 
                 PSImagePicker(title: "Product Image",
                               image: $image)
@@ -47,7 +49,7 @@ struct ShopProductEditFormView: View {
 
                 SaveEditedProductButton(product: product,
                                         name: $name, price: $price, description: $description, prepTime: $prepTime,
-                                        image: $image, category: $category, options: $options)
+                                        image: $image, category: $category, options: $options, tags: $tags)
             }
             .padding()
         }
@@ -69,6 +71,7 @@ struct SaveEditedProductButton: View {
     @Binding var image: UIImage?
     @Binding var category: String
     @Binding var options: [ProductOption]
+    @Binding var tags: [String]
 
     @State private var showAlert = false
     @State private var alertMessage = ""
@@ -121,6 +124,8 @@ struct SaveEditedProductButton: View {
             return nil
         }
 
+        let uniqueTags = Array(Set(tags.filter { !$0.isEmpty })).map { ProductTag(tag: $0) }
+
         // Create edited Product and save to db
         return Product(id: product.id,
                        name: name,
@@ -130,7 +135,7 @@ struct SaveEditedProductButton: View {
                        estimatedPrepTime: estimatedPrepTime,
                        isOutOfStock: false,
                        options: options,
-                       tags: [],
+                       tags: uniqueTags,
                        shopId: product.shopId,
                        shopName: product.shopName,
                        shopCategory: ShopCategory(title: category),

--- a/PocketShop/Views/ShopViews/ShopProductFormView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductFormView.swift
@@ -11,6 +11,7 @@ struct ShopProductFormView: View {
     @State private var image: UIImage?
     @State private var category = ""
     @State private var options = [ProductOption]()
+    @State private var tags = [String]()
 
     var body: some View {
         ScrollView(.vertical) {
@@ -23,7 +24,8 @@ struct ShopProductFormView: View {
                                  description: $description,
                                  prepTime: $prepTime,
                                  category: $category,
-                                 options: $options)
+                                 options: $options,
+                                 tags: $tags)
 
                 PSImagePicker(title: "Product Image", image: $image)
                     .padding(.bottom)
@@ -31,7 +33,7 @@ struct ShopProductFormView: View {
                 SaveNewProductButton(name: $name, price: $price,
                                      prepTime: $prepTime, description: $description,
                                      image: $image, category: $category,
-                                     options: $options)
+                                     options: $options, tags: $tags)
             }.padding()
         }
         .navigationBarItems(trailing: Button("Cancel") {
@@ -49,6 +51,7 @@ struct UserInputSegment: View {
     @Binding var prepTime: String
     @Binding var category: String
     @Binding var options: [ProductOption]
+    @Binding var tags: [String]
 
     var body: some View {
         VStack {
@@ -73,6 +76,8 @@ struct UserInputSegment: View {
                 .keyboardType(.numberPad)
 
             OptionGroupSection(options: $options)
+
+            TagsInputField(tags: $tags)
         }
     }
 }
@@ -88,6 +93,7 @@ struct SaveNewProductButton: View {
     @Binding var image: UIImage?
     @Binding var category: String
     @Binding var options: [ProductOption]
+    @Binding var tags: [String]
 
     @State private var showAlert = false
     @State private var alertMessage = ""
@@ -146,6 +152,8 @@ struct SaveNewProductButton: View {
             return nil
         }
 
+        let uniqueTags = Array(Set(tags.filter { !$0.isEmpty })).map { ProductTag(tag: $0) }
+
         return Product(id: "",
                        name: name,
                        description: description,
@@ -154,13 +162,35 @@ struct SaveNewProductButton: View {
                        estimatedPrepTime: estimatedPrepTime,
                        isOutOfStock: false,
                        options: options,
-                       tags: [],
+                       tags: uniqueTags,
                        shopId: shop.id,
                        shopName: shop.name,
                        shopCategory: ShopCategory(title: category),
                        subProductIds: [])
     }
 
+}
+
+struct TagsInputField: View {
+    @Binding var tags: [String]
+
+    var body: some View {
+        Text("PRODUCT TAGS (OPTIONAL)")
+            .font(.appSmallCaption)
+
+        ForEach(0..<tags.count, id: \.self) { index in
+            PSTextField(text: $tags[index],
+                        title: "Product Tag \(index + 1)",
+                        placeholder: "Product Tag \(index + 1)")
+        }
+
+        Button(action: {
+            tags.append("")
+        }, label: {
+            Text("\(Image(systemName: "plus.circle")) Add new product tag")
+        })
+        .padding(.vertical)
+    }
 }
 
 struct CategoryPickerSection: View {

--- a/PocketShop/Views/ShopViews/ShopProductFormView.swift
+++ b/PocketShop/Views/ShopViews/ShopProductFormView.swift
@@ -77,7 +77,9 @@ struct UserInputSegment: View {
 
             OptionGroupSection(options: $options)
 
-            TagsInputField(tags: $tags)
+            PSMultiLineTextField(groupTitle: "Product Tags (Optional)",
+                                 fieldTitle: "Product Tag",
+                                 fields: $tags)
         }
     }
 }
@@ -169,28 +171,6 @@ struct SaveNewProductButton: View {
                        subProductIds: [])
     }
 
-}
-
-struct TagsInputField: View {
-    @Binding var tags: [String]
-
-    var body: some View {
-        Text("PRODUCT TAGS (OPTIONAL)")
-            .font(.appSmallCaption)
-
-        ForEach(0..<tags.count, id: \.self) { index in
-            PSTextField(text: $tags[index],
-                        title: "Product Tag \(index + 1)",
-                        placeholder: "Product Tag \(index + 1)")
-        }
-
-        Button(action: {
-            tags.append("")
-        }, label: {
-            Text("\(Image(systemName: "plus.circle")) Add new product tag")
-        })
-        .padding(.vertical)
-    }
 }
 
 struct CategoryPickerSection: View {


### PR DESCRIPTION
Implemented the following changes (fixes #64):

General:
- Made a new `PSMultilineTextField` to encapsulate text fields that can be expanded to multiple rows
- Added a delete button to these multi-line text fields

Shop:
- Add tags to products
- Edit tags in products
- Delete tags from products (improved deleting UX via `PSMultiLineTextField`)

Customer:
- Searching now accounts for product tags. When a product's tag is entered into search field:
    - Product with tag appears in Products scroll view
    - Shop with the above product appears in Shops scroll view
    - Location with the above shop appears in Locations scroll view